### PR TITLE
Auto-unlock tiers and 6x6 crafting grid on selection

### DIFF
--- a/ui_main.py
+++ b/ui_main.py
@@ -639,7 +639,12 @@ class App(tk.Tk):
             self.tier_vars[t] = var
             r = i // cols
             c = i % cols
-            ttk.Checkbutton(grid, text=t, variable=var).grid(row=r, column=c, sticky="w", padx=8, pady=4)
+            ttk.Checkbutton(
+                grid,
+                text=t,
+                variable=var,
+                command=lambda tier=t: self._on_tier_toggle(tier),
+            ).grid(row=r, column=c, sticky="w", padx=8, pady=4)
 
         btns = ttk.Frame(tab)
         btns.pack(fill="x", pady=(10, 0))
@@ -668,6 +673,25 @@ class App(tk.Tk):
 
         if hasattr(self, "unlocked_6x6_var"):
             self.unlocked_6x6_var.set(self.is_crafting_6x6_unlocked())
+
+    def _on_tier_toggle(self, tier: str) -> None:
+        var = self.tier_vars.get(tier)
+        if not var or not var.get():
+            return
+
+        try:
+            tier_index = ALL_TIERS.index(tier)
+        except ValueError:
+            return
+
+        for lower_tier in ALL_TIERS[: tier_index + 1]:
+            lower_var = self.tier_vars.get(lower_tier)
+            if lower_var and not lower_var.get():
+                lower_var.set(True)
+
+        if "Steam Age" in ALL_TIERS[: tier_index + 1]:
+            if hasattr(self, "unlocked_6x6_var") and not self.unlocked_6x6_var.get():
+                self.unlocked_6x6_var.set(True)
 
     def _tiers_save_to_db(self):
         enabled = [t for t, var in self.tier_vars.items() if var.get()]


### PR DESCRIPTION
### Motivation
- Make the Tiers tab behave intuitively by auto-enabling prerequisite tiers when a higher tier is selected.
- Ensure selecting `Steam Age` also enables the 6x6 crafting grid unlock to match expected game progression.
- Prevent inconsistent UI state where a higher tier is checked but lower prerequisite tiers are not.
- Keep persistence of the enabled tiers and crafting unlocks in the profile DB unchanged.

### Description
- Added a `command=lambda tier=t: self._on_tier_toggle(tier)` to each tier `Checkbutton` in `_build_tiers_tab` to react to user toggles.
- Implemented `_on_tier_toggle` which locates the selected tier in `ALL_TIERS` and sets all tiers up to that index to checked.
- `_on_tier_toggle` also sets the `unlocked_6x6_var` to true if `Steam Age` is included among the newly enabled tiers.
- Left existing load/save persistence logic (`_tiers_load_from_db`, `_tiers_save_to_db`, `set_enabled_tiers`, `set_crafting_6x6_unlocked`) unchanged.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d5d30f0f4832b88d9261d84fc8f1b)