### PR TITLE
Add pytest suite and GitHub Actions CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: tests
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+      - name: Run tests
+        run: |
+          pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -1,0 +1,44 @@
+import sqlite3
+
+import db
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return {row["name"] for row in rows}
+
+
+def test_ensure_schema_creates_tables_and_defaults():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    db.ensure_schema(conn)
+
+    tables = {
+        row["name"]
+        for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+    assert "items" in tables
+    assert "item_kinds" in tables
+    assert "recipes" in tables
+    assert "recipe_lines" in tables
+    assert "app_settings" in tables
+
+    item_columns = _table_columns(conn, "items")
+    for column in (
+        "item_kind_id",
+        "is_machine",
+        "machine_tier",
+        "machine_input_slots",
+        "machine_output_slots",
+    ):
+        assert column in item_columns
+
+    recipe_columns = _table_columns(conn, "recipes")
+    for column in ("method", "grid_size", "station_item_id", "machine_item_id"):
+        assert column in recipe_columns
+
+    machine_kind = conn.execute(
+        "SELECT id FROM item_kinds WHERE LOWER(name)=LOWER('Machine')"
+    ).fetchone()
+    assert machine_kind is not None

--- a/tests/test_profile_db.py
+++ b/tests/test_profile_db.py
@@ -1,0 +1,23 @@
+import sqlite3
+
+import db
+
+
+def test_connect_profile_creates_tables(tmp_path):
+    profile_path = tmp_path / "profile.db"
+    conn = db.connect_profile(profile_path)
+    try:
+        tables = {
+            row["name"]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+        assert "app_settings" in tables
+        assert "inventory" in tables
+
+        inventory_cols = {
+            row["name"]
+            for row in conn.execute("PRAGMA table_info(inventory)").fetchall()
+        }
+        assert {"item_id", "qty_count", "qty_liters"}.issubset(inventory_cols)
+    finally:
+        conn.close()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,17 @@
+import sqlite3
+
+import db
+
+
+def test_settings_round_trip():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    db.ensure_schema(conn)
+
+    assert db.get_setting(conn, "missing", "default") == "default"
+
+    db.set_setting(conn, "foo", "bar")
+    assert db.get_setting(conn, "foo") == "bar"
+
+    db.set_setting(conn, "foo", "baz")
+    assert db.get_setting(conn, "foo") == "baz"


### PR DESCRIPTION
### Motivation
- Add an initial automated test suite to cover core database behavior and prevent regressions in schema and settings handling.
- Verify that profile DB creation and inventory schema are correct via automated tests.
- Ensure tests run on CI for every push and pull request to catch issues early.

### Description
- Add `tests/test_db_schema.py`, `tests/test_settings.py`, and `tests/test_profile_db.py` which exercise `db.ensure_schema`, `db.get_setting`/`db.set_setting`, and `db.connect_profile` respectively.
- Add `tests/conftest.py` which inserts the repository root onto `sys.path` so test modules can `import db`.
- Add a GitHub Actions workflow at `.github/workflows/tests.yml` that sets up Python and runs `pytest` on pushes to `main`/`master` and on pull requests.

### Testing
- Running `pytest` initially produced import errors due to the test environment not finding the `db` module (automated run).
- After adding `tests/conftest.py`, running `pytest` again collected 3 tests and they all passed.
- Final automated test run: `3 passed` (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d726722c4832baaf9863e28ef286d)