### PR TITLE
Switch machine slot indices to zero-based

### DIFF
--- a/ui_main.py
+++ b/ui_main.py
@@ -525,7 +525,7 @@ class App(tk.Tk):
             # Chance outputs (e.g., macerator byproducts)
             if x["direction"] == "out":
                 slot_idx = x["output_slot_index"]
-                if slot_idx:
+                if slot_idx is not None:
                     s = f"{s} (Slot {slot_idx})"
                 ch = x["chance_percent"]
                 if ch is not None:


### PR DESCRIPTION
### Motivation
- Align internal and UI handling of machine input/output slots to 0-based indices so slot 0 is the default base slot.
- Prevent confusion caused by mixed 1-based/0-based indexing between stored DB values, dialogs, and displays.
- Provide a safe migration path for existing DBs that currently store 1-based slot indices.

### Description
- Updated `ui_dialogs.py` to use 0-based slot numbering: changed UI labels from `In {i+1}`/`Out {i+1}` to `In {i}`/`Out {i}`, switched `enumerate(..., start=1)` usages to `start=0` when persisting `machine_io_slots`, and adjusted slot-loading logic to index with `i` instead of `i+1`.
- Added normalization when loading `machine_io_slots` so legacy 1-based maps are shifted to 0-based when needed (`_normalize_slot_map` in `EditItemDialog`).
- Updated output-slot selection and validation logic in `ui_dialogs.py` and `ItemLineDialog` so slot `0` is treated as the default fixed slot and available slot ranges are computed as `range(0, mos)`, and adjusted chance-required checks to treat `<= 0` as base.
- Fixed display logic to show slot 0 by checking `is not None` when rendering `output_slot_index` in `ui_dialogs.py` and `ui_main.py`.
- Added a one-time DB migration in `db.py` (driven by `PRAGMA user_version`) that detects machines whose stored slot indices are 1-based and atomically shifts `machine_io_slots.slot_index` and `recipe_lines.output_slot_index` down by 1, then sets `user_version=1`.

### Testing
- No automated tests were executed as part of this change.
- Manual smoke: code paths for loading/saving items, adding/editing recipe outputs, and rendering recipe details were updated to allow slot index `0` to be visible and selectable (manual verification recommended after upgrade).
- Migration runs during normal `ensure_schema` when opening content DBs (guarded by `user_version`) and is designed to be idempotent for already-upgraded DBs.
- Recommend running existing unit/integration tests and exercising the item/recipe UI flows after upgrading DB files to validate behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d7a36f334832b9e99c0936ca6d409)