### PR TITLE
Centralize ALL_TIERS in db module

### DIFF
--- a/db.py
+++ b/db.py
@@ -5,6 +5,26 @@ from pathlib import Path
 from typing import Any
 
 DEFAULT_DB_PATH = Path("gtnh.db")
+ALL_TIERS = [
+    "Stone Age",
+    "Steam Age",
+    "ULV",
+    "LV",
+    "MV",
+    "HV",
+    "EV",
+    "IV",
+    "LuV",
+    "ZPM",
+    "UV",
+    "UHV",
+    "UEV",
+    "UIV",
+    "UMV",
+    "UXV",
+    "OpV",
+    "MAX",
+]
 
 
 def connect_profile(db_path: Path | str) -> sqlite3.Connection:

--- a/ui_dialogs.py
+++ b/ui_dialogs.py
@@ -2,6 +2,8 @@
 import tkinter as tk
 from tkinter import ttk, messagebox, simpledialog
 
+from db import ALL_TIERS
+
 
 def _row_get(row, key: str, default=None):
     """Safe key access for sqlite3.Row/dicts."""
@@ -32,15 +34,6 @@ def _safe_grab(win, tries=20):
         if tries <= 0:
             return
         win.after(50, lambda: _safe_grab(win, tries - 1))
-
-ALL_TIERS = [
-    "Stone Age",
-    "Steam Age",
-    "ULV", "LV", "MV", "HV", "EV", "IV",
-    "LuV", "ZPM", "UV",
-    "UHV", "UEV", "UIV", "UMV", "UXV",
-    "OpV", "MAX",
-]
 
 # User-facing label for "no tier" (stored as NULL in DB)
 NONE_TIER_LABEL = "— none —"

--- a/ui_main.py
+++ b/ui_main.py
@@ -5,6 +5,7 @@ import tkinter as tk
 from tkinter import ttk, messagebox, filedialog
 
 from db import (
+    ALL_TIERS,
     connect,
     connect_profile,
     get_setting,
@@ -14,15 +15,6 @@ from db import (
     merge_database,
 )
 from ui_dialogs import AddItemDialog, EditItemDialog, AddRecipeDialog, EditRecipeDialog
-
-ALL_TIERS = [
-    "Stone Age",
-    "Steam Age",
-    "ULV", "LV", "MV", "HV", "EV", "IV",
-    "LuV", "ZPM", "UV",
-    "UHV", "UEV", "UIV", "UMV", "UXV",
-    "OpV", "MAX",
-]
 
 SETTINGS_ENABLED_TIERS = "enabled_tiers"
 SETTINGS_CRAFT_6X6_UNLOCKED = "crafting_6x6_unlocked"


### PR DESCRIPTION
### Motivation
- Remove duplicated `ALL_TIERS` definitions to provide a single source of truth and avoid divergence between UI modules.
- Prevent runtime bugs where adding a new tier in one place and not the other could hide recipes or crash dialogs.

### Description
- Add `ALL_TIERS` constant to `db.py` to centralize the tier list.
- Update `ui_main.py` and `ui_dialogs.py` to import `ALL_TIERS` from `db` and remove their local definitions.
- No behavioral changes beyond sharing the same `ALL_TIERS` value across modules.

### Testing
- No automated tests were executed as part of this change.
- Manual import smokechecks were performed during development (no automated failures reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d7f8e5a10832baea501da384f306d)