### PR TITLE
Prefer profile.db for per-user profile and migrate legacy <stem>.profile.db

### DIFF
--- a/ui_main.py
+++ b/ui_main.py
@@ -75,10 +75,17 @@ class App(tk.Tk):
         try:
             content_path = Path(content_path)
             # Keep the profile next to the content DB for portability.
-            stem = content_path.stem or "gtnh"
-            return content_path.with_name(f"{stem}.profile.db")
+            new_path = content_path.with_name("profile.db")
+            legacy_stem = content_path.stem or "gtnh"
+            legacy_path = content_path.with_name(f"{legacy_stem}.profile.db")
+            if legacy_path.exists() and not new_path.exists():
+                try:
+                    legacy_path.rename(new_path)
+                except Exception:
+                    return legacy_path
+            return new_path
         except Exception:
-            return Path("gtnh.profile.db")
+            return Path("profile.db")
 
     def _open_content_db(self, path: Path):
         """Open content DB respecting client/editor mode.


### PR DESCRIPTION
### Motivation
- Use a single, consistent filename `profile.db` for per-user profile data located alongside the content DB.
- Migrate existing installations that used the legacy `<stem>.profile.db` name to the new `profile.db` to avoid lost user data.
- Keep backward-compatible behavior when migration fails so the app can still use the legacy file.

### Description
- Updated `_profile_path_for_content` to prefer `profile.db` next to the content DB by returning `content_path.with_name("profile.db")`.
- Detects a legacy profile at `content_path.with_name(f"{stem}.profile.db")` and renames it to `profile.db` when present and the new path does not exist.
- If renaming fails the code falls back to returning the legacy path, and on unexpected exceptions it returns `Path("profile.db")` instead of `Path("gtnh.profile.db")`.
- Change is contained to `ui_main.py` and preserves existing migration and error-handling semantics.

### Testing
- Ran the test suite with `pytest`.
- Collected 3 tests and all tests passed.
- Test run completed successfully (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d9c2e4b44832ba71e45eab867cb9e)