### PR TITLE
Add machine IO slot labels to schema and dialogs

### DIFF
--- a/db.py
+++ b/db.py
@@ -163,11 +163,14 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
         direction TEXT NOT NULL CHECK(direction IN ('in','out')),
         slot_index INTEGER NOT NULL,
         content_kind TEXT NOT NULL CHECK(content_kind IN ('item','fluid')),
+        label TEXT,
         UNIQUE(machine_item_id, direction, slot_index),
         FOREIGN KEY(machine_item_id) REFERENCES items(id) ON DELETE CASCADE
     )
     """
     )
+    if not _has_col("machine_io_slots", "label"):
+        conn.execute("ALTER TABLE machine_io_slots ADD COLUMN label TEXT")
 
     # Seed defaults for item_kinds (only if the table is empty)
     existing = conn.execute("SELECT COUNT(1) AS c FROM item_kinds").fetchone()["c"]


### PR DESCRIPTION
### Motivation
- Provide per-slot human-readable labels for machine IO slots and persist them in the content DB.
- Make labels editable in the Add/Edit item dialogs so users can describe slot purpose (e.g., “Input 1 (Circuit)”).
- Ensure existing databases migrate cleanly by adding a lightweight schema migration for the new field.

### Description
- Add a nullable `label` column to the `machine_io_slots` table and perform an `ALTER TABLE` migration when missing in `ensure_schema` (`db.py`).
- Extend `AddItemDialog` and `EditItemDialog` in `ui_dialogs.py` with `in_slot_label_vars`/`out_slot_label_vars`, add `ttk.Entry` widgets next to slot type selectors, and update the resizing logic for var lists.
- Load `label` values from `machine_io_slots` when opening the dialogs and include `label` in the `INSERT` statements when saving per-slot IO rows so labels are persisted.

### Testing
- Ran `pytest`, which executed the automated test suite and returned `3 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695da1c99778832bb8dbe6d292615c18)