### PR TITLE
Remove duplicate slot label list initialization

### DIFF
--- a/ui_dialogs.py
+++ b/ui_dialogs.py
@@ -445,10 +445,6 @@ class AddItemDialog(tk.Toplevel):
         self.out_slot_kind_vars = []
         self.in_slot_label_vars = []
         self.out_slot_label_vars = []
-        self.in_slot_label_vars = []
-        self.out_slot_label_vars = []
-        self.in_slot_label_vars = []
-        self.out_slot_label_vars = []
 
         # Keep slot UI in sync with slot counts
         self.machine_input_slots_var.trace_add("write", lambda *_: self._on_slots_changed())


### PR DESCRIPTION
### Motivation
- Remove redundant duplicate initializations of per-slot label lists in `AddItemDialog` to fix a copy-paste stutter. 
- Improve code readability and avoid unnecessary reassignments of `self.in_slot_label_vars` and `self.out_slot_label_vars`.

### Description
- Deleted repeated assignments of `self.in_slot_label_vars` and `self.out_slot_label_vars` in `ui_dialogs.py` during `AddItemDialog` construction. 
- The change is a small cleanup with no intended behavioral impact.

### Testing
- Ran `pytest` to verify no regressions. 
- All tests passed (`tests/test_db_schema.py`, `tests/test_profile_db.py`, and `tests/test_settings.py`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695da75eb138832bbebd63cfae159351)