### PR TITLE
Refactor UI data access into services

### DIFF
--- a/services/db_lifecycle.py
+++ b/services/db_lifecycle.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from services.db import (
+    DEFAULT_DB_PATH,
+    connect,
+    connect_profile,
+    export_db,
+    get_setting,
+    merge_database,
+    set_setting,
+)
+from ui_constants import SETTINGS_CRAFT_6X6_UNLOCKED, SETTINGS_ENABLED_TIERS
+
+
+@dataclass
+class DbLifecycle:
+    editor_enabled: bool
+    db_path: Path = DEFAULT_DB_PATH
+    conn: object = field(init=False, default=None)
+    profile_db_path: Path | None = field(init=False, default=None)
+    profile_conn: object = field(init=False, default=None)
+
+    def __post_init__(self) -> None:
+        self.db_path = Path(self.db_path)
+        self.conn = self._open_content_db(self.db_path)
+        self.profile_db_path = self._profile_path_for_content(self.db_path)
+        self.profile_conn = connect_profile(self.profile_db_path)
+        self._migrate_profile_settings_if_needed()
+
+    def close(self) -> None:
+        try:
+            if self.conn is not None:
+                self.conn.commit()
+                self.conn.close()
+        except Exception:
+            pass
+
+        try:
+            if self.profile_conn is not None:
+                self.profile_conn.commit()
+                self.profile_conn.close()
+        except Exception:
+            pass
+
+    def switch_db(self, new_path: Path) -> None:
+        self.close()
+        self.db_path = Path(new_path)
+        self.conn = self._open_content_db(self.db_path)
+        self.profile_db_path = self._profile_path_for_content(self.db_path)
+        self.profile_conn = connect_profile(self.profile_db_path)
+        self._migrate_profile_settings_if_needed()
+
+    def export_content_db(self, target: Path) -> None:
+        export_db(self.conn, target)
+
+    def export_profile_db(self, target: Path) -> None:
+        export_db(self.profile_conn, target)
+
+    def merge_db(self, source: Path) -> dict:
+        return merge_database(self.conn, source)
+
+    def get_enabled_tiers(self) -> list[str]:
+        raw = get_setting(self.profile_conn, SETTINGS_ENABLED_TIERS, "")
+        if not raw:
+            return ["Stone Age"]
+        tiers = [t.strip() for t in raw.split(",") if t.strip()]
+        return tiers if tiers else ["Stone Age"]
+
+    def set_enabled_tiers(self, tiers: list[str]) -> None:
+        set_setting(self.profile_conn, SETTINGS_ENABLED_TIERS, ",".join(tiers))
+
+    def is_crafting_6x6_unlocked(self) -> bool:
+        raw = (get_setting(self.profile_conn, SETTINGS_CRAFT_6X6_UNLOCKED, "0") or "0").strip()
+        return raw == "1"
+
+    def set_crafting_6x6_unlocked(self, unlocked: bool) -> None:
+        set_setting(self.profile_conn, SETTINGS_CRAFT_6X6_UNLOCKED, "1" if unlocked else "0")
+
+    def _open_content_db(self, path: Path):
+        try:
+            return connect(path, read_only=(not self.editor_enabled))
+        except Exception:
+            return connect(":memory:")
+
+    def _profile_path_for_content(self, content_path: Path) -> Path:
+        try:
+            content_path = Path(content_path)
+            new_path = content_path.with_name("profile.db")
+            legacy_stem = content_path.stem or "gtnh"
+            legacy_path = content_path.with_name(f"{legacy_stem}.profile.db")
+            if legacy_path.exists() and not new_path.exists():
+                try:
+                    legacy_path.rename(new_path)
+                except Exception:
+                    return legacy_path
+            return new_path
+        except Exception:
+            return Path("profile.db")
+
+    def _migrate_profile_settings_if_needed(self) -> None:
+        try:
+            for key in (SETTINGS_ENABLED_TIERS, SETTINGS_CRAFT_6X6_UNLOCKED):
+                prof_val = get_setting(self.profile_conn, key, None)
+                if prof_val is not None and str(prof_val).strip() != "":
+                    continue
+                src_val = get_setting(self.conn, key, None)
+                if src_val is None or str(src_val).strip() == "":
+                    continue
+                set_setting(self.profile_conn, key, str(src_val))
+        except Exception:
+            pass

--- a/services/items.py
+++ b/services/items.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import sqlite3
+
+
+def fetch_items(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+    return conn.execute(
+        "SELECT i.id, i.key, COALESCE(i.display_name, i.key) AS name, i.kind, i.is_base, i.is_machine, i.machine_tier, "
+        "       i.machine_input_slots, i.machine_output_slots, i.machine_storage_slots, i.machine_power_slots, "
+        "       i.machine_circuit_slots, i.machine_input_tanks, i.machine_input_tank_capacity_l, "
+        "       i.machine_output_tanks, i.machine_output_tank_capacity_l, "
+        "       k.name AS item_kind_name "
+        "FROM items i "
+        "LEFT JOIN item_kinds k ON k.id = i.item_kind_id "
+        "ORDER BY name"
+    ).fetchall()

--- a/services/recipes.py
+++ b/services/recipes.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import sqlite3
+
+
+def fetch_recipes(conn: sqlite3.Connection, enabled_tiers: list[str]) -> list[sqlite3.Row]:
+    if not enabled_tiers:
+        enabled_tiers = ["Stone Age"]
+    placeholders = ",".join(["?"] * len(enabled_tiers))
+    sql = (
+        "SELECT id, name, method, machine, machine_item_id, grid_size, station_item_id, tier, circuit, duration_ticks, eu_per_tick "
+        "FROM recipes "
+        f"WHERE (tier IS NULL OR TRIM(tier)='' OR tier IN ({placeholders})) "
+        "ORDER BY name"
+    )
+    return conn.execute(sql, tuple(enabled_tiers)).fetchall()
+
+
+def fetch_recipe_lines(conn: sqlite3.Connection, recipe_id: int) -> list[sqlite3.Row]:
+    return conn.execute(
+        """
+        SELECT rl.direction, COALESCE(i.display_name, i.key) AS name, rl.qty_count, rl.qty_liters, rl.chance_percent, rl.output_slot_index
+        FROM recipe_lines rl
+        JOIN items i ON i.id = rl.item_id
+        WHERE rl.recipe_id=?
+        ORDER BY rl.id
+        """,
+        (recipe_id,),
+    ).fetchall()
+
+
+def fetch_item_name(conn: sqlite3.Connection, item_id: int) -> str:
+    row = conn.execute(
+        "SELECT COALESCE(display_name, key) AS name FROM items WHERE id=?",
+        (item_id,),
+    ).fetchone()
+    return row["name"] if row else ""
+
+
+def fetch_machine_output_slots(conn: sqlite3.Connection, machine_item_id: int) -> int | None:
+    row = conn.execute(
+        "SELECT machine_output_slots FROM items WHERE id=?",
+        (machine_item_id,),
+    ).fetchone()
+    if not row:
+        return None
+    try:
+        return int(row["machine_output_slots"] or 1)
+    except Exception:
+        return 1

--- a/services/tab_config.py
+++ b/services/tab_config.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class TabConfig:
+    order: list[str]
+    enabled: list[str]
+
+
+def config_path(base_dir: Path, filename: str = "ui_config.json") -> Path:
+    return base_dir / filename
+
+
+def load_tab_config(path: Path, tab_ids: Iterable[str]) -> TabConfig:
+    default_order = list(tab_ids)
+    default_enabled = list(default_order)
+    try:
+        raw = json.loads(path.read_text())
+    except Exception:
+        return TabConfig(order=default_order, enabled=default_enabled)
+
+    order = raw.get("tab_order", default_order)
+    enabled = raw.get("enabled_tabs", default_enabled)
+    order = [tid for tid in order if tid in default_order]
+    for tid in default_order:
+        if tid not in order:
+            order.append(tid)
+    enabled = [tid for tid in enabled if tid in order]
+    if not enabled:
+        enabled = list(default_enabled)
+    enabled_ordered = [tid for tid in order if tid in enabled]
+    return TabConfig(order=order, enabled=enabled_ordered)
+
+
+def save_tab_config(path: Path, order: list[str], enabled: list[str]) -> None:
+    data = {"enabled_tabs": enabled, "tab_order": order}
+    path.write_text(json.dumps(data, indent=2))
+
+
+def apply_tab_reorder(
+    current_order: list[str],
+    enabled_tabs: list[str],
+    orders: dict[str, int],
+) -> TabConfig:
+    if any(tab_id not in current_order for tab_id in orders):
+        raise ValueError("Unknown tab id in ordering data.")
+    max_order = len(current_order)
+    for tab_id, order_val in orders.items():
+        if order_val < 1 or order_val > max_order:
+            raise ValueError(f"Order for {tab_id} must be within the allowed range.")
+    if len(set(orders.values())) != len(current_order):
+        raise ValueError("Order values must be unique.")
+
+    new_order = [tab_id for tab_id, _ in sorted(orders.items(), key=lambda item: item[1])]
+    enabled_set = set(enabled_tabs)
+    new_enabled = [tab_id for tab_id in new_order if tab_id in enabled_set]
+    if not new_enabled:
+        raise ValueError("At least one tab must remain enabled.")
+    return TabConfig(order=new_order, enabled=new_enabled)

--- a/ui_main.py
+++ b/ui_main.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 import datetime
-import json
 from pathlib import Path
 import tkinter as tk
 from tkinter import ttk, messagebox, filedialog
 
-from services.db import connect, connect_profile, get_setting, set_setting, DEFAULT_DB_PATH, export_db, merge_database
-from ui_constants import SETTINGS_CRAFT_6X6_UNLOCKED, SETTINGS_ENABLED_TIERS
+from services.db import DEFAULT_DB_PATH
+from services.db_lifecycle import DbLifecycle
+from services.items import fetch_items
+from services.tab_config import apply_tab_reorder, config_path, load_tab_config, save_tab_config
 from ui_tabs.inventory_tab import InventoryTab
 from ui_tabs.items_tab import ItemsTab
 from ui_tabs.planner_tab import PlannerTab
@@ -23,17 +24,8 @@ class App(tk.Tk):
         # next to this script enables editor capabilities.
         self.editor_enabled = self._detect_editor_enabled()
 
-        self.db_path: Path = DEFAULT_DB_PATH
-        self.conn = self._open_content_db(self.db_path)
-
-        # Per-user profile DB (stores tiers/unlocks/etc). Kept separate from content
-        # so players can keep progress across content DB updates.
-        self.profile_db_path: Path = self._profile_path_for_content(self.db_path)
-        self.profile_conn = connect_profile(self.profile_db_path)
-
-        # Backward-compat: older versions stored tiers/unlocks in the content DB.
-        # If we detect those and the profile is empty, copy them over.
-        self._migrate_profile_settings_if_needed()
+        self.db = DbLifecycle(editor_enabled=self.editor_enabled, db_path=DEFAULT_DB_PATH)
+        self._sync_db_handles()
 
         self.status = tk.StringVar(value="Ready")
 
@@ -73,85 +65,29 @@ class App(tk.Tk):
         except Exception:
             return False
 
-    def _profile_path_for_content(self, content_path: Path) -> Path:
-        try:
-            content_path = Path(content_path)
-            # Keep the profile next to the content DB for portability.
-            new_path = content_path.with_name("profile.db")
-            legacy_stem = content_path.stem or "gtnh"
-            legacy_path = content_path.with_name(f"{legacy_stem}.profile.db")
-            if legacy_path.exists() and not new_path.exists():
-                try:
-                    legacy_path.rename(new_path)
-                except Exception:
-                    return legacy_path
-            return new_path
-        except Exception:
-            return Path("profile.db")
-
-    def _open_content_db(self, path: Path):
-        """Open content DB respecting client/editor mode.
-
-        In client mode, we open the content DB read-only. If the file does not
-        exist yet, we fall back to an empty in-memory DB and prompt the user to
-        open a content DB.
-        """
-        try:
-            return connect(path, read_only=(not self.editor_enabled))
-        except Exception:
-            # Client-mode bootstrap: allow the app to start even without a DB.
-            # Users can File -> Open DB… to select the shipped content DB.
-            return connect(":memory:")
-
-    def _migrate_profile_settings_if_needed(self) -> None:
-        """One-time migration from content DB -> profile DB."""
-        try:
-            for k in (SETTINGS_ENABLED_TIERS, SETTINGS_CRAFT_6X6_UNLOCKED):
-                prof_v = get_setting(self.profile_conn, k, None)
-                if prof_v is not None and str(prof_v).strip() != "":
-                    continue
-                src_v = get_setting(self.conn, k, None)
-                if src_v is None or str(src_v).strip() == "":
-                    continue
-                set_setting(self.profile_conn, k, str(src_v))
-        except Exception:
-            # Non-fatal: worst case users re-check tiers once.
-            pass
+    def _sync_db_handles(self) -> None:
+        self.db_path = self.db.db_path
+        self.profile_db_path = self.db.profile_db_path
+        self.conn = self.db.conn
+        self.profile_conn = self.db.profile_conn
 
     # ---------- Tab configuration ----------
     def _config_path(self) -> Path:
         try:
             here = Path(__file__).resolve().parent
-            return here / "ui_config.json"
+            return config_path(here)
         except Exception:
-            return Path("ui_config.json")
+            return config_path(Path("."))
 
     def _load_ui_config(self) -> tuple[list[str], list[str]]:
-        default_order = list(self.tab_registry.keys())
-        default_enabled = list(default_order)
         path = self._config_path()
-        try:
-            raw = json.loads(path.read_text())
-        except Exception:
-            return default_order, default_enabled
-
-        order = raw.get("tab_order", default_order)
-        enabled = raw.get("enabled_tabs", default_enabled)
-        order = [tid for tid in order if tid in self.tab_registry]
-        for tid in default_order:
-            if tid not in order:
-                order.append(tid)
-        enabled = [tid for tid in enabled if tid in self.tab_registry]
-        if not enabled:
-            enabled = list(default_enabled)
-        enabled_ordered = [tid for tid in order if tid in enabled]
-        return order, enabled_ordered
+        config = load_tab_config(path, self.tab_registry.keys())
+        return config.order, config.enabled
 
     def _save_ui_config(self) -> None:
         path = self._config_path()
-        data = {"enabled_tabs": self.enabled_tabs, "tab_order": self.tab_order}
         try:
-            path.write_text(json.dumps(data, indent=2))
+            save_tab_config(path, self.tab_order, self.enabled_tabs)
         except Exception as exc:
             messagebox.showwarning("Config save failed", f"Could not save tab preferences.\n\nDetails: {exc}")
 
@@ -226,18 +162,16 @@ class App(tk.Tk):
                 except ValueError:
                     messagebox.showerror("Invalid order", "Each tab must have a numeric order.")
                     return
-                if order_val < 1 or order_val > len(self.tab_order):
-                    messagebox.showerror("Invalid order", "Order values must be within the allowed range.")
-                    return
                 orders[tab_id] = order_val
 
-            if len(set(orders.values())) != len(self.tab_order):
-                messagebox.showerror("Invalid order", "Order values must be unique.")
+            try:
+                config = apply_tab_reorder(self.tab_order, self.enabled_tabs, orders)
+            except ValueError as exc:
+                messagebox.showerror("Invalid order", str(exc))
                 return
 
-            self.tab_order = [tid for tid, _ in sorted(orders.items(), key=lambda item: item[1])]
-            enabled_set = set(self.enabled_tabs)
-            self.enabled_tabs = [tid for tid in self.tab_order if tid in enabled_set]
+            self.tab_order = config.order
+            self.enabled_tabs = config.enabled
             self._save_ui_config()
             self._rebuild_tabs()
             self.refresh_items()
@@ -294,26 +228,8 @@ class App(tk.Tk):
 
     def _switch_db(self, new_path: Path):
         """Close current DB connection and open a new one."""
-        try:
-            if getattr(self, "conn", None) is not None:
-                self.conn.commit()
-                self.conn.close()
-        except Exception:
-            pass
-
-        try:
-            if getattr(self, "profile_conn", None) is not None:
-                self.profile_conn.commit()
-                self.profile_conn.close()
-        except Exception:
-            pass
-
-        self.db_path = Path(new_path)
-        self.conn = self._open_content_db(self.db_path)
-
-        self.profile_db_path = self._profile_path_for_content(self.db_path)
-        self.profile_conn = connect_profile(self.profile_db_path)
-        self._migrate_profile_settings_if_needed()
+        self.db.switch_db(Path(new_path))
+        self._sync_db_handles()
         self._update_title()
 
         # Reload UI from the new DB
@@ -362,7 +278,7 @@ class App(tk.Tk):
         if not path:
             return
         try:
-            export_db(self.conn, Path(path))
+            self.db.export_content_db(Path(path))
         except Exception as e:
             messagebox.showerror("Export failed", f"Could not export DB.\n\nDetails: {e}")
             return
@@ -381,7 +297,7 @@ class App(tk.Tk):
         if not path:
             return
         try:
-            export_db(self.profile_conn, Path(path))
+            self.db.export_profile_db(Path(path))
         except Exception as e:
             messagebox.showerror("Export failed", f"Could not export profile DB.\n\nDetails: {e}")
             return
@@ -410,7 +326,7 @@ class App(tk.Tk):
             return
 
         try:
-            stats = merge_database(self.conn, Path(path))
+            stats = self.db.merge_db(Path(path))
         except Exception as e:
             messagebox.showerror("Merge failed", f"Could not merge DB.\n\nDetails: {e}")
             return
@@ -431,36 +347,21 @@ class App(tk.Tk):
 
     # ---------- Tiers ----------
     def get_enabled_tiers(self):
-        # Stored per-player in the profile DB.
-        raw = get_setting(self.profile_conn, SETTINGS_ENABLED_TIERS, "")
-        if not raw:
-            return ["Stone Age"]  # default on first run
-        tiers = [t.strip() for t in raw.split(",") if t.strip()]
-        return tiers if tiers else ["Stone Age"]
+        return self.db.get_enabled_tiers()
 
     def set_enabled_tiers(self, tiers: list[str]):
-        set_setting(self.profile_conn, SETTINGS_ENABLED_TIERS, ",".join(tiers))
+        self.db.set_enabled_tiers(tiers)
 
     # ---------- Crafting grid unlocks ----------
     def is_crafting_6x6_unlocked(self) -> bool:
-        raw = (get_setting(self.profile_conn, SETTINGS_CRAFT_6X6_UNLOCKED, "0") or "0").strip()
-        return raw == "1"
+        return self.db.is_crafting_6x6_unlocked()
 
     def set_crafting_6x6_unlocked(self, unlocked: bool) -> None:
-        set_setting(self.profile_conn, SETTINGS_CRAFT_6X6_UNLOCKED, "1" if unlocked else "0")
+        self.db.set_crafting_6x6_unlocked(unlocked)
 
     # ---------- Tab delegates ----------
     def refresh_items(self) -> None:
-        self.items = self.conn.execute(
-            "SELECT i.id, i.key, COALESCE(i.display_name, i.key) AS name, i.kind, i.is_base, i.is_machine, i.machine_tier, "
-            "       i.machine_input_slots, i.machine_output_slots, i.machine_storage_slots, i.machine_power_slots, "
-            "       i.machine_circuit_slots, i.machine_input_tanks, i.machine_input_tank_capacity_l, "
-            "       i.machine_output_tanks, i.machine_output_tank_capacity_l, "
-            "       k.name AS item_kind_name "
-            "FROM items i "
-            "LEFT JOIN item_kinds k ON k.id = i.item_kind_id "
-            "ORDER BY name"
-        ).fetchall()
+        self.items = fetch_items(self.conn)
         if getattr(self, "items_tab", None) is not None:
             self.items_tab.render_items(self.items)
         if getattr(self, "inventory_tab", None) is not None:


### PR DESCRIPTION
### Motivation

- Decouple UI code from direct database and config operations to simplify maintenance and enable reuse.
- Move profile/db lifecycle and file-oriented operations out of `ui_main` to centralize DB handling.
- Extract item and recipe data access so UI tabs stop embedding SQL and can call testable helpers.
- Centralize tab ordering and persistence logic to reduce duplication and improve validation.

### Description

- Added `services/db_lifecycle.py` with a `DbLifecycle` dataclass to manage content/profile DB connections, `switch_db`, `export_*`, `merge_db`, and profile setting helpers.
- Added `services/items.py` (`fetch_items`) and `services/recipes.py` (`fetch_recipes`, `fetch_recipe_lines`, `fetch_item_name`, `fetch_machine_output_slots`) to host former inline SQL logic.
- Added `services/tab_config.py` with `TabConfig`, `load_tab_config`, `save_tab_config`, and `apply_tab_reorder`, and updated `ui_main.py` to use these helpers and to keep DB handles in sync via `DbLifecycle` and `_sync_db_handles`.
- Updated `ui_tabs/recipes_tab.py` to call the new recipe service functions and removed its inline queries, and switched `ui_main.py` to use `DbLifecycle` methods for exporting/merging/profile operations and `fetch_items` for item refreshes.

### Testing

- Ran `pytest` from the project root using `pytest`.
- Test suite executed 3 tests.
- All tests passed (`3 passed`).
- No UI/manual tests were performed as part of this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dd428c488832bbb4637efdb28e786)