### PR TITLE
Close db lifecycle connections on app exit

### DIFF
--- a/ui_main.py
+++ b/ui_main.py
@@ -226,6 +226,12 @@ class App(tk.Tk):
         mode = "Editor" if self.editor_enabled else "Client"
         self.title(f"GTNH Recipe DB — {mode} — {name}")
 
+    def destroy(self):
+        try:
+            self.db.close()
+        finally:
+            super().destroy()
+
     def _switch_db(self, new_path: Path):
         """Close current DB connection and open a new one."""
         self.db.switch_db(Path(new_path))


### PR DESCRIPTION
### Motivation
- Ensure the app cleanly closes content and profile DB connections when the UI shuts down to avoid leaked handles.
- Avoid stale connection references after closing to reduce risk of accidental use of closed DB objects.
- Improve type clarity for DB handles to make intent explicit and help static analysis.

### Description
- Tightened `DbLifecycle` connection attributes to use `sqlite3.Connection | None` and reset them to `None` in `close()` finally blocks.
- Added `App.destroy()` to call `self.db.close()` before delegating to `super().destroy()` to ensure connections are closed on exit.
- Updated DB switching to use `DbLifecycle.switch_db()` and keep UI handles in sync via `self._sync_db_handles()`.

### Testing
- Ran `pytest` from the project root using `pytest`.
- Test suite executed 3 tests and all tests passed (`3 passed`).
- No automated UI tests were run as part of this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dd428c488832bbb4637efdb28e786)