### PR TITLE
Fix planner step headers to show input item names

### DIFF
--- a/ui_tabs/planner_tab.py
+++ b/ui_tabs/planner_tab.py
@@ -161,8 +161,9 @@ class PlannerTab(ttk.Frame):
             steps_lines = []
             for idx, step in enumerate(result.steps, start=1):
                 inputs = ", ".join([f"{name} × {qty} {unit}" for name, qty, unit in step.inputs])
+                input_names = " + ".join([name for name, _, _ in step.inputs]) if step.inputs else "(none)"
                 steps_lines.append(
-                    f"{idx}. {step.recipe_name} → {step.output_item_name} "
+                    f"{idx}. {input_names} → {step.output_item_name} "
                     f"(x{step.multiplier}, output {step.output_qty})\n"
                     f"   Inputs: {inputs if inputs else '(none)'}"
                 )


### PR DESCRIPTION
### Motivation
- The planner displayed recipe names in step headers which caused confusing lines like "Crushed Iron Ore → Crushed Iron Ore" instead of showing which inputs produce the output. 
- The intent is to make process steps more readable by showing the input item names leading to the produced item. 

### Description
- Replace the step header content to join input item names with ` + ` and show that as the left-hand side of the arrow. 
- Add an `input_names` variable that becomes `" + ".join(...)` or `"(none)"` when there are no inputs. 
- Update the formatted step string in `ui_tabs/planner_tab.py` to use `input_names` instead of `step.recipe_name`.

### Testing
- Ran `pytest` which executed the test suite. 
- All tests passed: 3 passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e9e25527c832bb1e3f567219b7cb9)