### PR TITLE
Keep inventory selection when editing quantity

### DIFF
--- a/ui_tabs/inventory_tab.py
+++ b/ui_tabs/inventory_tab.py
@@ -20,7 +20,7 @@ class InventoryTab(ttk.Frame):
         right = ttk.Frame(body)
         right.pack(side="right", fill="both", expand=True, padx=(12, 0))
 
-        self.inventory_list = tk.Listbox(left, width=40)
+        self.inventory_list = tk.Listbox(left, width=40, exportselection=False)
         self.inventory_list.pack(fill="y", expand=True)
         self.inventory_list.bind("<<ListboxSelect>>", self.on_inventory_select)
 


### PR DESCRIPTION
### Motivation
- Selecting the quantity `Entry` in the Inventory tab caused the listbox highlight to disappear due to default selection export behavior. 
- The UI should retain the selected item while editing its fields so save/clear actions operate on the intended item. 

### Description
- Set `exportselection=False` on the `tk.Listbox` in `ui_tabs/inventory_tab.py` to keep the selection when focus moves to the quantity `Entry`. 
- No other UI logic or database interactions were changed. 

### Testing
- Ran `pytest` to exercise the test suite. 
- All tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eaa9a6dbc832b9f824ea71eb73f57)