### PR TITLE
Make planner panes resizable and hide process steps by default

### DIFF
--- a/ui_tabs/planner_tab.py
+++ b/ui_tabs/planner_tab.py
@@ -331,10 +331,10 @@ class PlannerTab(ttk.Frame):
             machine_line = f"Machine: {machine_name}"
         circuit_text = "(none)" if step.circuit in (None, "") else step.circuit
         return (
-            f"{idx}. Output: {step.output_item_name} × {total_output} {step.output_unit}\n"
+            f"{idx}. Inputs: {inputs_text}\n"
             f"   {machine_line}\n"
             f"   Circuit: {circuit_text}\n"
-            f"   Inputs: {inputs_text}"
+            f"   Output: {step.output_item_name} × {total_output} {step.output_unit}"
         )
 
     def _set_build_placeholder(self, text: str) -> None:


### PR DESCRIPTION
### Motivation

- Allow users to resize the three planner areas (Shopping List, Process Steps, Build Steps) rather than using fixed frames so layouts can be adjusted to preference.  
- Hide `Process Steps` by default because `Build Steps` is preferred and the intermediate steps are optional.  
- Prevent the `Process Steps` area from being accidentally removed completely while still allowing it to be shown/hidden.  

### Description

- Replace the previous fixed frames with a vertical `ttk.Panedwindow` (`main_pane`) and a horizontal `ttk.Panedwindow` (`results_pane`) to make panes resizable and add `minsize` and `weight` settings.  
- Move the `Process Steps` widget into its own pane (`self.steps_frame`) and add/remove that pane from `results_pane` in `_toggle_steps_visibility` instead of packing/unpacking the internal text widget.  
- Move the visibility toggle for process steps into the planner controls as a `Show Process Steps` checkbox and default `show_steps_var` to `False`, and update persisted/default state handling accordingly.  

### Testing

- Ran `pytest` which collected 3 tests and all passed.  
- No GUI unit tests were present; changes were limited to UI layout code and state persistence.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eb885591c832b93d65fa9e564f77a)