### PR TITLE
Add planner, tab config, and merge DB tests

### DIFF
--- a/tests/test_merge_db.py
+++ b/tests/test_merge_db.py
@@ -1,0 +1,66 @@
+import sqlite3
+from pathlib import Path
+
+from services.db import ensure_schema, merge_db
+
+
+def _connect(path: Path | str) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    ensure_schema(conn)
+    return conn
+
+
+def _insert_item(conn: sqlite3.Connection, *, key: str, name: str | None, is_base: int = 0):
+    conn.execute(
+        "INSERT INTO items(key, display_name, kind, is_base) VALUES(?,?,?,?)",
+        (key, name, "item", is_base),
+    )
+    return conn.execute("SELECT last_insert_rowid() AS id").fetchone()["id"]
+
+
+def test_merge_db_imports_items_and_recipes(tmp_path: Path):
+    dest_conn = _connect(":memory:")
+    dest_conn.execute("INSERT INTO item_kinds(name, sort_order, is_builtin) VALUES('Custom', 1, 0)")
+    existing_id = _insert_item(dest_conn, key="iron", name=None, is_base=0)
+
+    src_path = tmp_path / "src.db"
+    src_conn = _connect(src_path)
+    src_conn.execute("INSERT INTO item_kinds(name, sort_order, is_builtin) VALUES('Widget', 5, 0)")
+
+    iron_id = _insert_item(src_conn, key="iron", name="Iron Ingot", is_base=1)
+    widget_id = _insert_item(src_conn, key="widget", name="Widget", is_base=0)
+
+    src_conn.execute("INSERT INTO recipes(name, method) VALUES('Make Widget', 'crafting')")
+    recipe_id = src_conn.execute("SELECT last_insert_rowid() AS id").fetchone()["id"]
+    src_conn.execute(
+        "INSERT INTO recipe_lines(recipe_id, direction, item_id, qty_count) VALUES(?,?,?,?)",
+        (recipe_id, "in", iron_id, 2),
+    )
+    src_conn.execute(
+        "INSERT INTO recipe_lines(recipe_id, direction, item_id, qty_count) VALUES(?,?,?,?)",
+        (recipe_id, "out", widget_id, 1),
+    )
+    src_conn.commit()
+
+    stats = merge_db(dest_conn, src_path)
+
+    assert stats["kinds_added"] == 1
+    assert stats["items_added"] == 1
+    assert stats["items_updated"] == 1
+    assert stats["recipes_added"] == 1
+    assert stats["lines_added"] == 2
+
+    merged_iron = dest_conn.execute("SELECT display_name, is_base FROM items WHERE id=?", (existing_id,)).fetchone()
+    assert merged_iron["display_name"] == "Iron Ingot"
+    assert merged_iron["is_base"] == 1
+
+    widget = dest_conn.execute("SELECT id FROM items WHERE key='widget'").fetchone()
+    assert widget is not None
+
+    recipe = dest_conn.execute("SELECT id FROM recipes WHERE name='Make Widget'").fetchone()
+    assert recipe is not None
+
+    lines = dest_conn.execute("SELECT item_id FROM recipe_lines WHERE recipe_id=?", (recipe["id"],)).fetchall()
+    item_ids = {row["item_id"] for row in lines}
+    assert widget["id"] in item_ids

--- a/tests/test_tab_config.py
+++ b/tests/test_tab_config.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from services.tab_config import load_tab_config, save_tab_config, apply_tab_reorder
+
+
+def test_load_tab_config_handles_invalid_file(tmp_path: Path):
+    path = tmp_path / "ui_config.json"
+    path.write_text("not-json")
+
+    config = load_tab_config(path, ["alpha", "beta"])
+
+    assert config.order == ["alpha", "beta"]
+    assert config.enabled == ["alpha", "beta"]
+
+
+def test_load_tab_config_filters_and_recovers_defaults(tmp_path: Path):
+    path = tmp_path / "ui_config.json"
+    raw = {"tab_order": ["beta", "ghost"], "enabled_tabs": ["ghost"]}
+    path.write_text(json.dumps(raw))
+
+    config = load_tab_config(path, ["alpha", "beta", "gamma"])
+
+    assert config.order == ["beta", "alpha", "gamma"]
+    assert config.enabled == ["beta", "alpha", "gamma"]
+
+
+def test_save_and_apply_tab_reorder(tmp_path: Path):
+    path = tmp_path / "ui_config.json"
+
+    config = apply_tab_reorder(
+        ["alpha", "beta", "gamma"],
+        ["alpha", "gamma"],
+        {"alpha": 2, "beta": 1, "gamma": 3},
+    )
+
+    save_tab_config(path, config.order, config.enabled)
+    saved = json.loads(path.read_text())
+
+    assert saved == {"enabled_tabs": ["alpha", "gamma"], "tab_order": ["beta", "alpha", "gamma"]}
+
+
+def test_apply_tab_reorder_rejects_empty_enabled():
+    with pytest.raises(ValueError, match="At least one tab must remain enabled"):
+        apply_tab_reorder(["alpha"], [], {"alpha": 1})


### PR DESCRIPTION
### Motivation
- Bring automated tests in line with current code and cover previously-untested core logic in the planner service.
- Ensure pure-Python tab configuration logic is validated to avoid corrupting UI config files.
- Verify `merge_db` behavior to prevent duplicate items or corrupted recipe imports during DB merges.
- Improve confidence in critical paths (recipe planning, tab ordering, DB merging) before further changes.

### Description
- Add `tests/test_planner.py` to exercise recipe chaining, inventory overrides via `inventory_override`, and missing-recipe error reporting for `PlannerService`.
- Add `tests/test_tab_config.py` to validate `load_tab_config`, `save_tab_config`, and `apply_tab_reorder` behavior and validation.
- Add `tests/test_merge_db.py` to create a source DB and assert `merge_db` properly merges kinds, fills item fields, imports recipes, and remaps recipe lines.
- Tests use in-memory or temporary SQLite DBs and call `ensure_schema` and `connect_profile` helpers to set up the schema.

### Testing
- Ran `pytest` to execute the full test suite.
- All automated tests passed successfully with `10 passed`.
- The new tests exercise the planner, tab config, and DB merge code paths and reported no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ed6adcff8832b807673531dbc1d71)