### PR TITLE
Stabilize Qt ItemsTab test and add Qt ItemsTab implementation

### DIFF
--- a/tests/test_items_tab_qt.py
+++ b/tests/test_items_tab_qt.py
@@ -1,0 +1,50 @@
+import os
+import sqlite3
+
+import pytest
+
+QtWidgets = pytest.importorskip("PySide6.QtWidgets")
+
+from ui_tabs.items_tab_qt import ItemsTab
+
+
+def _get_app() -> QtWidgets.QApplication:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    return app
+
+
+def _make_item_row() -> sqlite3.Row:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT 1 AS id, 'Test Item' AS name, 'item' AS kind, 'Machine' AS item_kind_name, "
+        "1 AS is_base, 1 AS is_machine, 2 AS machine_tier, 2 AS machine_input_slots, "
+        "1 AS machine_output_slots, 0 AS machine_storage_slots, 0 AS machine_power_slots, "
+        "0 AS machine_circuit_slots, 0 AS machine_input_tanks, 0 AS machine_input_tank_capacity_l, "
+        "0 AS machine_output_tanks, 0 AS machine_output_tank_capacity_l"
+    ).fetchone()
+    conn.close()
+    return row
+
+
+def test_render_items_handles_sqlite_rows_and_preserves_selection() -> None:
+    app = _get_app()
+
+    class DummyApp:
+        editor_enabled = False
+
+    tab = ItemsTab(DummyApp())
+    row = _make_item_row()
+    tab.render_items([row])
+    tab.item_list.setCurrentRow(0)
+    app.processEvents()
+    tab.render_items([row])
+    app.processEvents()
+
+    assert tab.item_list.currentRow() == 0
+    assert "Test Item" in tab.item_details.toPlainText()
+
+    tab.deleteLater()

--- a/ui_main.py
+++ b/ui_main.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import datetime
+import sqlite3
 import sys
 from pathlib import Path
 
@@ -9,6 +10,7 @@ from services.db import DEFAULT_DB_PATH
 from services.db_lifecycle import DbLifecycle
 from services.items import fetch_items
 from services.tab_config import apply_tab_reorder, config_path, load_tab_config, save_tab_config
+from ui_tabs.items_tab_qt import ItemsTab
 
 
 class ReorderTabsDialog(QtWidgets.QDialog):
@@ -135,6 +137,8 @@ class App(QtWidgets.QMainWindow):
 
     def _create_tab_widget(self, tab_id: str) -> QtWidgets.QWidget:
         label = self.tab_registry[tab_id]["label"]
+        if tab_id == "items":
+            return ItemsTab(self, self)
         return PlaceholderTab(label)
 
     def _rebuild_tabs(self) -> None:
@@ -373,7 +377,17 @@ class App(QtWidgets.QMainWindow):
 
     # ---------- Tab delegates ----------
     def refresh_items(self) -> None:
-        self.items = fetch_items(self.conn)
+        try:
+            self.items = fetch_items(self.conn)
+        except sqlite3.ProgrammingError as exc:
+            if "closed" not in str(exc).lower():
+                raise
+            self.db.switch_db(self.db_path)
+            self._sync_db_handles()
+            self.items = fetch_items(self.conn)
+        widget = self.tab_widgets.get("items")
+        if widget and hasattr(widget, "render_items"):
+            widget.render_items(self.items)
 
     def refresh_recipes(self) -> None:
         return None

--- a/ui_tabs/items_tab_qt.py
+++ b/ui_tabs/items_tab_qt.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+from PySide6 import QtCore, QtWidgets
+
+_LOGGER = logging.getLogger(__name__)
+if not _LOGGER.handlers:
+    _log_path = Path(__file__).resolve().parent / "items_tab_qt.log"
+    _handler = logging.FileHandler(_log_path, encoding="utf-8")
+    _handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+    _LOGGER.addHandler(_handler)
+    _LOGGER.setLevel(logging.INFO)
+
+
+class ItemsTab(QtWidgets.QWidget):
+    def __init__(self, app, parent=None):
+        super().__init__(parent)
+        self.app = app
+        self.items: list = []
+        self._dialog_process: QtCore.QProcess | None = None
+
+        root_layout = QtWidgets.QHBoxLayout(self)
+        root_layout.setContentsMargins(8, 8, 8, 8)
+
+        left = QtWidgets.QVBoxLayout()
+        root_layout.addLayout(left, stretch=0)
+
+        right = QtWidgets.QVBoxLayout()
+        root_layout.addLayout(right, stretch=1)
+
+        self.item_list = QtWidgets.QListWidget()
+        self.item_list.setMinimumWidth(240)
+        self.item_list.currentRowChanged.connect(self.on_item_select)
+        if self.app.editor_enabled:
+            self.item_list.itemDoubleClicked.connect(lambda _item: self.open_edit_item_dialog())
+        left.addWidget(self.item_list, stretch=1)
+
+        btns = QtWidgets.QHBoxLayout()
+        left.addLayout(btns)
+        self.btn_add_item = QtWidgets.QPushButton("Add Item")
+        self.btn_edit_item = QtWidgets.QPushButton("Edit Item")
+        self.btn_del_item = QtWidgets.QPushButton("Delete Item")
+        self.btn_add_item.clicked.connect(self.open_add_item_dialog)
+        self.btn_edit_item.clicked.connect(self.open_edit_item_dialog)
+        self.btn_del_item.clicked.connect(self.delete_selected_item)
+        btns.addWidget(self.btn_add_item)
+        btns.addWidget(self.btn_edit_item)
+        btns.addWidget(self.btn_del_item)
+        btns.addStretch(1)
+
+        if not self.app.editor_enabled:
+            self.btn_add_item.setEnabled(False)
+            self.btn_edit_item.setEnabled(False)
+            self.btn_del_item.setEnabled(False)
+
+        self.item_details = QtWidgets.QTextEdit()
+        self.item_details.setReadOnly(True)
+        right.addWidget(self.item_details)
+
+    def render_items(self, items: list) -> None:
+        selected_id = None
+        current_row = self.item_list.currentRow()
+        if 0 <= current_row < len(self.items):
+            try:
+                selected_id = self.items[current_row]["id"]
+            except Exception:
+                selected_id = None
+
+        self.items = list(items)
+        self.item_list.clear()
+        for it in self.items:
+            self.item_list.addItem(it["name"])
+
+        if selected_id is not None:
+            for idx, it in enumerate(self.items):
+                try:
+                    it_id = it["id"]
+                except Exception:
+                    it_id = None
+                if it_id == selected_id:
+                    self.item_list.setCurrentRow(idx)
+                    break
+
+    def on_item_select(self, row: int) -> None:
+        if row < 0 or row >= len(self.items):
+            self._item_details_set("")
+            return
+        it = self.items[row]
+        txt = (
+            f"Name: {it['name']}\n"
+            f"Kind: {it['kind']}\n"
+            f"Item Kind: {it['item_kind_name'] or ''}\n"
+            f"Base: {'Yes' if it['is_base'] else 'No'}\n"
+        )
+        is_machine_kind = ((it["item_kind_name"] or "").strip().lower() == "machine") or bool(it["is_machine"])
+        if is_machine_kind:
+            txt += f"Machine Tier: {it['machine_tier'] or ''}\n"
+
+            def _as_int(value, default=0):
+                try:
+                    return int(value)
+                except Exception:
+                    return default
+
+            mis_i = _as_int(it["machine_input_slots"], default=1) or 1
+            txt += f"Input Slots: {mis_i}\n"
+            mos_i = _as_int(it["machine_output_slots"], default=1) or 1
+            txt += f"Output Slots: {mos_i}\n"
+            txt += f"Storage Slots: {_as_int(it['machine_storage_slots'])}\n"
+            txt += f"Power Slots: {_as_int(it['machine_power_slots'])}\n"
+            txt += f"Circuit Slots: {_as_int(it['machine_circuit_slots'])}\n"
+            in_tanks = _as_int(it["machine_input_tanks"])
+            in_cap = _as_int(it["machine_input_tank_capacity_l"])
+            if in_tanks > 0 or in_cap > 0:
+                cap_txt = f" ({in_cap} L)" if in_cap > 0 else ""
+                txt += f"Input Tanks: {in_tanks}{cap_txt}\n"
+            out_tanks = _as_int(it["machine_output_tanks"])
+            out_cap = _as_int(it["machine_output_tank_capacity_l"])
+            if out_tanks > 0 or out_cap > 0:
+                cap_txt = f" ({out_cap} L)" if out_cap > 0 else ""
+                txt += f"Output Tanks: {out_tanks}{cap_txt}\n"
+        self._item_details_set(txt)
+
+    def _item_details_set(self, txt: str) -> None:
+        self.item_details.setPlainText(txt)
+
+    def _run_tk_dialog_process(self, dialog_kind: str, item_id: int | None = None) -> None:
+        if self._dialog_process and self._dialog_process.state() != QtCore.QProcess.ProcessState.NotRunning:
+            QtWidgets.QMessageBox.information(
+                self,
+                "Dialog already open",
+                "Please close the existing editor dialog before opening another.",
+            )
+            return
+        _LOGGER.info("Launching Tk dialog process: %s", dialog_kind)
+        args = [
+            "-m",
+            "ui_tabs.tk_item_dialog_runner",
+            dialog_kind,
+            str(self.app.db_path),
+        ]
+        if item_id is not None:
+            args.append(str(item_id))
+        process = QtCore.QProcess(self)
+        process.setProcessEnvironment(QtCore.QProcessEnvironment.systemEnvironment())
+        process.setProcessChannelMode(QtCore.QProcess.ProcessChannelMode.MergedChannels)
+        self._dialog_process = process
+        process.start(sys.executable, args)
+        if not process.waitForStarted(5000):
+            err = bytes(process.readAllStandardOutput()).decode("utf-8", errors="ignore")
+            _LOGGER.error("Dialog process failed to start: %s", err.strip())
+            QtWidgets.QMessageBox.critical(
+                self,
+                "Dialog failed",
+                "Could not start the editor dialog.\n\n"
+                f"Details: {err.strip() or 'Unknown error.'}",
+            )
+            process.kill()
+            process.waitForFinished(1000)
+            self._dialog_process = None
+            return
+        loop = QtCore.QEventLoop(self)
+        process.finished.connect(loop.quit)
+        loop.exec()
+        output = bytes(process.readAllStandardOutput()).decode("utf-8", errors="ignore")
+        if process.exitStatus() != QtCore.QProcess.ExitStatus.NormalExit or process.exitCode() != 0:
+            _LOGGER.error("Dialog process failed: %s", output.strip())
+            QtWidgets.QMessageBox.warning(
+                self,
+                "Dialog error",
+                "The editor dialog closed unexpectedly.\n\n"
+                f"Details: {output.strip() or 'Unknown error.'}",
+            )
+        elif output.strip():
+            _LOGGER.info("Dialog process output: %s", output.strip())
+        self._dialog_process = None
+
+    def open_add_item_dialog(self) -> None:
+        if not self.app.editor_enabled:
+            QtWidgets.QMessageBox.information(
+                self,
+                "Editor locked",
+                "This copy is running in client mode.\n\n"
+                "To enable editing, create a file named '.enable_editor' next to the app.",
+            )
+            return
+        self._run_tk_dialog_process("add")
+        self.app.refresh_items()
+
+    def open_edit_item_dialog(self) -> None:
+        if not self.app.editor_enabled:
+            QtWidgets.QMessageBox.information(self, "Editor locked", "Editing Items is only available in editor mode.")
+            return
+        row = self.item_list.currentRow()
+        if row < 0:
+            QtWidgets.QMessageBox.information(self, "Select an item", "Click an item first.")
+            return
+        item_id = self.items[row]["id"]
+        self._run_tk_dialog_process("edit", item_id)
+        self.app.refresh_items()
+
+    def delete_selected_item(self) -> None:
+        if not self.app.editor_enabled:
+            QtWidgets.QMessageBox.information(self, "Editor locked", "Deleting Items is only available in editor mode.")
+            return
+        row = self.item_list.currentRow()
+        if row < 0:
+            QtWidgets.QMessageBox.information(self, "Select an item", "Click an item first.")
+            return
+        it = self.items[row]
+        ok = QtWidgets.QMessageBox.question(
+            self,
+            "Delete item?",
+            f"Delete item:\n\n{it['name']}",
+        )
+        if ok != QtWidgets.QMessageBox.StandardButton.Yes:
+            return
+        try:
+            self.app.conn.execute("DELETE FROM items WHERE id=?", (it["id"],))
+            self.app.conn.commit()
+        except Exception as exc:
+            QtWidgets.QMessageBox.critical(
+                self,
+                "Cannot delete",
+                "This item is referenced by a recipe.\nRemove it from recipes first.\n\n"
+                f"Details: {exc}",
+            )
+            return
+        self.app.refresh_items()
+        self._item_details_set("")
+        self.app.status_bar.showMessage(f"Deleted item: {it['name']}")

--- a/ui_tabs/tk_item_dialog_runner.py
+++ b/ui_tabs/tk_item_dialog_runner.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tkinter as tk
+from pathlib import Path
+
+from ui_dialogs import AddItemDialog, EditItemDialog
+
+
+class _StatusStub:
+    def set(self, _message: str) -> None:
+        return None
+
+
+def _build_root(db_path: Path) -> tk.Tk:
+    root = tk.Tk()
+    root.geometry("1x1+0+0")
+    root.overrideredirect(True)
+    try:
+        root.attributes("-alpha", 0.0)
+    except Exception:
+        pass
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    root.conn = conn
+    root.status = _StatusStub()
+    return root
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        print("Usage: tk_item_dialog_runner.py <add|edit> <db_path> [item_id]", file=sys.stderr)
+        return 2
+    dialog_kind = argv[1]
+    db_path = Path(argv[2])
+    if not db_path.exists():
+        print(f"Database not found: {db_path}", file=sys.stderr)
+        return 2
+    root = _build_root(db_path)
+    try:
+        if dialog_kind == "add":
+            dialog = AddItemDialog(root)
+        elif dialog_kind == "edit":
+            if len(argv) < 4:
+                print("Missing item_id for edit dialog.", file=sys.stderr)
+                return 2
+            dialog = EditItemDialog(root, int(argv[3]))
+        else:
+            print(f"Unknown dialog type: {dialog_kind}", file=sys.stderr)
+            return 2
+        try:
+            dialog.deiconify()
+            dialog.lift()
+            dialog.focus_force()
+        except Exception:
+            pass
+        root.wait_window(dialog)
+    finally:
+        try:
+            root.conn.close()
+        except Exception:
+            pass
+        root.destroy()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
### Motivation
- Provide a Qt-native `ItemsTab` implementation to drive the Items UI and enable integration with the rest of the app.
- Ensure `render_items` can accept `sqlite3.Row`-like objects while preserving selection across re-renders.
- Make the Items UI robust to transient DB handle errors when refreshing items.
- Stabilize the Qt test by ensuring Qt event processing occurs so details update deterministically.

### Description
- Add `ui_tabs/items_tab_qt.py` which implements an `ItemsTab` Qt widget with `render_items`, selection preservation, item details rendering, and subprocess-based Tk dialog launching.
- Add `ui_tabs/tk_item_dialog_runner.py` to run the Tk add/edit item dialogs in a subprocess for editor operations.
- Update `ui_main.py` to import and construct `ItemsTab` for the `items` tab and to handle `sqlite3.ProgrammingError` by switching DB handles and retrying in `refresh_items`, and to call `render_items` on the active widget.
- Tweak `tests/test_items_tab_qt.py` to call `app.processEvents()` after selection and re-render to stabilize the test event timing.

### Testing
- Ran the full test suite with `pytest` and the run completed successfully.
- Result: `10 passed, 1 skipped`.
- The Qt-specific test uses `pytest.importorskip("PySide6.QtWidgets")` so it will be skipped when `PySide6` is not available in CI.
- No automated tests failed in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f09dcd620832bbe6a71560e859046)