### PR TITLE
Rebuild item and recipe dialogs with Qt

### DIFF
--- a/ui_tabs/tk_recipe_dialog_runner.py
+++ b/ui_tabs/tk_recipe_dialog_runner.py
@@ -2,30 +2,29 @@ from __future__ import annotations
 
 import sqlite3
 import sys
-import tkinter as tk
 from pathlib import Path
 
+from PySide6 import QtWidgets
+
 from ui_dialogs import AddRecipeDialog, EditRecipeDialog
+from services.db import ALL_TIERS
 
 
-class _StatusStub:
-    def set(self, _message: str) -> None:
+class _StatusBarStub:
+    def showMessage(self, _message: str) -> None:
         return None
 
 
-def _build_root(db_path: Path) -> tk.Tk:
-    root = tk.Tk()
-    root.geometry("1x1+0+0")
-    root.overrideredirect(True)
-    try:
-        root.attributes("-alpha", 0.0)
-    except Exception:
-        pass
-    conn = sqlite3.connect(db_path)
-    conn.row_factory = sqlite3.Row
-    root.conn = conn
-    root.status = _StatusStub()
-    return root
+class _AppStub:
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+        self.status_bar = _StatusBarStub()
+
+    def get_enabled_tiers(self):
+        return ALL_TIERS
+
+    def is_crafting_6x6_unlocked(self) -> bool:
+        return True
 
 
 def main(argv: list[str]) -> int:
@@ -37,31 +36,27 @@ def main(argv: list[str]) -> int:
     if not db_path.exists():
         print(f"Database not found: {db_path}", file=sys.stderr)
         return 2
-    root = _build_root(db_path)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    app = QtWidgets.QApplication([])
+    stub = _AppStub(conn)
     try:
         if dialog_kind == "add":
-            dialog = AddRecipeDialog(root)
+            dialog = AddRecipeDialog(stub)
         elif dialog_kind == "edit":
             if len(argv) < 4:
                 print("Missing recipe_id for edit dialog.", file=sys.stderr)
                 return 2
-            dialog = EditRecipeDialog(root, int(argv[3]))
+            dialog = EditRecipeDialog(stub, int(argv[3]))
         else:
             print(f"Unknown dialog type: {dialog_kind}", file=sys.stderr)
             return 2
-        try:
-            dialog.deiconify()
-            dialog.lift()
-            dialog.focus_force()
-        except Exception:
-            pass
-        root.wait_window(dialog)
+        dialog.exec()
     finally:
         try:
-            root.conn.close()
+            conn.close()
         except Exception:
             pass
-        root.destroy()
     return 0
 
 


### PR DESCRIPTION
### Motivation
- Replace the existing Tkinter-based item/recipe dialogs with native Qt dialogs to integrate UI consistently across Qt tabs.
- Eliminate the need for spawning separate Tk processes from Qt tabs for editor dialogs.
- Provide a single dialog implementation used by Items, Recipes and Planner flows. 
- Keep existing DB-backed behavior and validations while moving to PySide6 widgets.

### Description
- Reimplemented all dialog UIs in `ui_dialogs.py` using PySide6 Qt and introduced Qt dialog classes such as `ItemPickerDialog`, `_ItemDialogBase`, `AddItemDialog`, `EditItemDialog`, `ItemLineDialog`, `_RecipeDialogBase`, `AddRecipeDialog`, and `EditRecipeDialog`.
- Updated `ui_tabs/items_tab_qt.py` and `ui_tabs/recipes_tab_qt.py` to open the new Qt dialogs directly (`AddItemDialog`, `EditItemDialog`, `AddRecipeDialog`, `EditRecipeDialog`) instead of launching separate Tk subprocesses.
- Converted the runner helpers `ui_tabs/tk_item_dialog_runner.py` and `ui_tabs/tk_recipe_dialog_runner.py` into lightweight Qt-based runners that construct minimal `app` stubs and `exec()` the Qt dialogs for standalone invocation.
- Preserved database interactions, validations and behavior (machine slot/tank logic, item kinds, recipe lines, tier handling) while improving widget layouts (e.g. stacked widgets for method/grid fields) and replacing message dialogs with Qt equivalents.

### Testing
- Ran the test suite with `pytest -q` which completed successfully with `10 passed, 1 skipped`.
- Exercised dialog creation flows via the updated unit/integration tests that cover item/recipe logic (no GUI-only automated tests added).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f2218c940832bafe9c07dc1ea6af9)