### PR TITLE
Port tiers tab to Qt

### DIFF
--- a/ui_main.py
+++ b/ui_main.py
@@ -14,6 +14,7 @@ from services.tab_config import apply_tab_reorder, config_path, load_tab_config,
 from ui_tabs.inventory_tab import InventoryTab
 from ui_tabs.items_tab_qt import ItemsTab
 from ui_tabs.recipes_tab_qt import RecipesTab
+from ui_tabs.tiers_tab import TiersTab
 
 
 class ReorderTabsDialog(QtWidgets.QDialog):
@@ -146,6 +147,8 @@ class App(QtWidgets.QMainWindow):
             return RecipesTab(self, self)
         if tab_id == "inventory":
             return InventoryTab(self, self)
+        if tab_id == "tiers":
+            return TiersTab(self, self)
         return PlaceholderTab(label)
 
     def _rebuild_tabs(self) -> None:
@@ -413,7 +416,9 @@ class App(QtWidgets.QMainWindow):
             widget.render_recipes(self.recipes)
 
     def _tiers_load_from_db(self) -> None:
-        return None
+        widget = self.tab_widgets.get("tiers")
+        if widget and hasattr(widget, "load_from_db"):
+            widget.load_from_db()
 
     def notify_inventory_change(self) -> None:
         return None


### PR DESCRIPTION
### Motivation
- Replace the existing Tkinter-based tiers UI with the Qt widget set used elsewhere in the app to provide a consistent UI.
- Use a grid layout for compact display of tier toggles and switch `Checkbutton` to `QCheckBox` for Qt integration.
- Preserve existing tier dependency rules (lower tiers auto-enabled, higher tiers cleared when a lower one is disabled) and crafting-unlock behavior.
- Wire the new Qt tab into the main window so tiers are loaded from and saved to the profile DB like other Qt tabs.

### Description
- Replace `ui_tabs/tiers_tab.py` with a Qt implementation using `QWidget`, `QGridLayout`, and `QCheckBox`, and add `_set_tier_checked` helper to manage signal blocking when changing check states.
- Preserve original dependency logic in `_on_tier_toggle` and keep the crafting 6x6 unlock behavior, while converting message dialogs to `QtWidgets.QMessageBox`.
- Save behavior now calls `app.set_enabled_tiers(...)` and `app.set_crafting_6x6_unlocked(...)`, triggers `refresh_recipes()` and clears recipe details, and updates the `status_bar` message.
- Integrate the tab into the app by importing `TiersTab` in `ui_main.py`, creating it in `_create_tab_widget` for the `tiers` id, and calling its `load_from_db()` from `_tiers_load_from_db()`.

### Testing
- Ran `pytest`, which completed successfully with `10 passed, 1 skipped`.
- No additional automated UI tests were added for the new Qt widget in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f2bc12bb0832b8dd8abb320fdd9e5)