### PR TITLE
Add tests to preserve UI settings keys

### DIFF
--- a/tests/test_ui_settings_keys.py
+++ b/tests/test_ui_settings_keys.py
@@ -1,0 +1,45 @@
+from services.db_lifecycle import DbLifecycle
+from ui_constants import SETTINGS_CRAFT_6X6_UNLOCKED, SETTINGS_ENABLED_TIERS
+
+
+def test_ui_settings_keys_are_preserved():
+    assert SETTINGS_ENABLED_TIERS == "enabled_tiers"
+    assert SETTINGS_CRAFT_6X6_UNLOCKED == "crafting_6x6_unlocked"
+
+
+def test_qt_ui_uses_settings_keys(tmp_path):
+    lifecycle = DbLifecycle(editor_enabled=False, db_path=tmp_path / "content.db")
+    try:
+        profile_conn = lifecycle.profile_conn
+        assert profile_conn is not None
+
+        profile_conn.execute("DELETE FROM app_settings")
+        profile_conn.execute(
+            "INSERT INTO app_settings(key, value) VALUES (?, ?)",
+            (SETTINGS_ENABLED_TIERS, "Stone Age,LV"),
+        )
+        profile_conn.execute(
+            "INSERT INTO app_settings(key, value) VALUES (?, ?)",
+            (SETTINGS_CRAFT_6X6_UNLOCKED, "1"),
+        )
+        profile_conn.commit()
+
+        assert lifecycle.get_enabled_tiers() == ["Stone Age", "LV"]
+        assert lifecycle.is_crafting_6x6_unlocked() is True
+
+        lifecycle.set_enabled_tiers(["MV"])
+        lifecycle.set_crafting_6x6_unlocked(False)
+
+        row = profile_conn.execute(
+            "SELECT value FROM app_settings WHERE key=?",
+            (SETTINGS_ENABLED_TIERS,),
+        ).fetchone()
+        assert row["value"] == "MV"
+
+        row = profile_conn.execute(
+            "SELECT value FROM app_settings WHERE key=?",
+            (SETTINGS_CRAFT_6X6_UNLOCKED,),
+        ).fetchone()
+        assert row["value"] == "0"
+    finally:
+        lifecycle.close()


### PR DESCRIPTION
### Motivation

- Preserve existing settings key names (like enabled tiers and crafting unlock) so UI state remains compatible.
- Ensure the Qt UI and lifecycle code read/write the same keys defined in `ui_constants.py`.
- Prevent regressions during UI refactors that might change the keys used in the profile `app_settings` table.

### Description

- Add `tests/test_ui_settings_keys.py` to assert `SETTINGS_ENABLED_TIERS` and `SETTINGS_CRAFT_6X6_UNLOCKED` match their expected string names.
- Verify `DbLifecycle` can read values from the profile `app_settings` using those keys via `get_enabled_tiers()` and `is_crafting_6x6_unlocked()`.
- Verify `set_enabled_tiers()` and `set_crafting_6x6_unlocked()` write the expected values back to `app_settings` using the same keys.

### Testing

- Ran the full test suite with `pytest`.
- All automated tests passed: `12 passed, 1 skipped`.
- The new `tests/test_ui_settings_keys.py` executed and succeeded as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fe608d5f4832bac9d2434efacd916)