### PR TITLE
Add machine metadata schema table

### DIFF
--- a/services/db.py
+++ b/services/db.py
@@ -55,6 +55,25 @@ def connect_profile(db_path: Path | str) -> sqlite3.Connection:
         )
         """
     )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS machine_metadata (
+            machine_type TEXT NOT NULL,
+            tier TEXT NOT NULL,
+            input_slots INTEGER,
+            output_slots INTEGER,
+            byproduct_slots INTEGER,
+            storage_slots INTEGER,
+            power_slots INTEGER,
+            circuit_slots INTEGER,
+            input_tanks INTEGER,
+            input_tank_capacity_l INTEGER,
+            output_tanks INTEGER,
+            output_tank_capacity_l INTEGER,
+            PRIMARY KEY (machine_type, tier)
+        )
+        """
+    )
     conn.commit()
     return conn
 
@@ -92,6 +111,26 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
         name TEXT NOT NULL UNIQUE,
         sort_order INTEGER NOT NULL DEFAULT 0,
         is_builtin INTEGER NOT NULL DEFAULT 0
+    )
+    """
+    )
+
+    conn.execute(
+        """
+    CREATE TABLE IF NOT EXISTS machine_metadata (
+        machine_type TEXT NOT NULL,
+        tier TEXT NOT NULL,
+        input_slots INTEGER,
+        output_slots INTEGER,
+        byproduct_slots INTEGER,
+        storage_slots INTEGER,
+        power_slots INTEGER,
+        circuit_slots INTEGER,
+        input_tanks INTEGER,
+        input_tank_capacity_l INTEGER,
+        output_tanks INTEGER,
+        output_tank_capacity_l INTEGER,
+        PRIMARY KEY (machine_type, tier)
     )
     """
     )

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -23,6 +23,7 @@ def test_ensure_schema_creates_tables_and_defaults():
     assert "recipes" in tables
     assert "recipe_lines" in tables
     assert "app_settings" in tables
+    assert "machine_metadata" in tables
 
     item_columns = _table_columns(conn, "items")
     for column in (
@@ -44,6 +45,23 @@ def test_ensure_schema_creates_tables_and_defaults():
     recipe_columns = _table_columns(conn, "recipes")
     for column in ("method", "grid_size", "station_item_id", "machine_item_id"):
         assert column in recipe_columns
+
+    metadata_columns = _table_columns(conn, "machine_metadata")
+    for column in (
+        "machine_type",
+        "tier",
+        "input_slots",
+        "output_slots",
+        "byproduct_slots",
+        "storage_slots",
+        "power_slots",
+        "circuit_slots",
+        "input_tanks",
+        "input_tank_capacity_l",
+        "output_tanks",
+        "output_tank_capacity_l",
+    ):
+        assert column in metadata_columns
 
     machine_kind = conn.execute(
         "SELECT id FROM item_kinds WHERE LOWER(name)=LOWER('Machine')"


### PR DESCRIPTION
### Motivation

- Provide a schema to store per-machine-type and per-tier capability limits so the app can reason about machine IO and tank capacities.
- Ensure both the global content DB and per-user profile DB can contain machine metadata for migrations and user-specific overrides.

### Description

- Create a new `machine_metadata` table with primary key `(machine_type, tier)` and columns for `input_slots`, `output_slots`, `byproduct_slots`, `storage_slots`, `power_slots`, `circuit_slots`, `input_tanks`, `input_tank_capacity_l`, `output_tanks`, and `output_tank_capacity_l` in `services/db.py` during both profile DB initialization (`connect_profile`) and content DB schema setup (`ensure_schema`).
- Add assertions in `tests/test_db_schema.py` to verify the `machine_metadata` table exists and that all expected columns are present.

### Testing

- Ran `pytest` to validate the schema and related behavior.
- All automated tests passed: `16 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696028ad1954832b83801f2492e9c6db)