### PR TITLE
Add profile machine availability tracking

### DIFF
--- a/services/db.py
+++ b/services/db.py
@@ -74,6 +74,17 @@ def connect_profile(db_path: Path | str) -> sqlite3.Connection:
         )
         """
     )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS machine_availability (
+            machine_type TEXT NOT NULL,
+            tier TEXT NOT NULL,
+            owned INTEGER NOT NULL DEFAULT 0 CHECK(owned >= 0),
+            online INTEGER NOT NULL DEFAULT 0 CHECK(online >= 0 AND online <= owned),
+            PRIMARY KEY (machine_type, tier)
+        )
+        """
+    )
     conn.commit()
     return conn
 

--- a/services/db_lifecycle.py
+++ b/services/db_lifecycle.py
@@ -95,6 +95,21 @@ class DbLifecycle:
         value = theme.strip().lower()
         set_setting(self.profile_conn, SETTINGS_THEME, value)
 
+    def get_machine_availability(self, machine_type: str, tier: str) -> dict[str, int]:
+        if self.profile_conn is None:
+            return {"owned": 0, "online": 0}
+        row = self.profile_conn.execute(
+            """
+            SELECT owned, online
+            FROM machine_availability
+            WHERE machine_type = ? AND tier = ?
+            """,
+            (machine_type, tier),
+        ).fetchone()
+        if row is None:
+            return {"owned": 0, "online": 0}
+        return {"owned": int(row["owned"] or 0), "online": int(row["online"] or 0)}
+
     def _profile_path_for_content(self, content_path: Path) -> Path:
         content_path = Path(content_path)
         base_dir = content_path.parent


### PR DESCRIPTION
### Motivation
- Implement profile-level tracking for machine ownership and online counts keyed by `machine_type` + `tier`.
- Enforce `online <= owned` at the database level to prevent inconsistent machine availability values.
- Expose a simple app-layer accessor to let UI and services query machine availability from the profile DB.

### Description
- Create a `machine_availability` table in `connect_profile` with `owned` and `online` integer columns, a composite primary key `(machine_type, tier)`, and CHECK constraints to require non-negative counts and `online <= owned`.
- Add `DbLifecycle.get_machine_availability(machine_type: str, tier: str)` to fetch availability and return a `{"owned": int, "online": int}` defaulting to zeros when no row or profile DB is present.
- Return zero defaults when `profile_conn` is missing or the requested machine row does not exist.

### Testing
- Ran the test suite with `pytest`.
- Test results: `16 passed, 1 skipped` (all executed tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69602af07b50832b946d5be66578179a)