### PR TITLE
Filter recipes by online machine availability

### DIFF
--- a/services/recipes.py
+++ b/services/recipes.py
@@ -3,18 +3,62 @@ from __future__ import annotations
 import sqlite3
 
 
-def fetch_recipes(conn: sqlite3.Connection, enabled_tiers: list[str]) -> list[sqlite3.Row]:
+def load_online_machine_availability(profile_conn: sqlite3.Connection | None) -> dict[str, set[str]]:
+    if profile_conn is None:
+        return {}
+    rows = profile_conn.execute(
+        "SELECT machine_type, tier, online FROM machine_availability",
+    ).fetchall()
+    available: dict[str, set[str]] = {}
+    for row in rows:
+        online = int(row["online"] or 0)
+        if online <= 0:
+            continue
+        machine_type = (row["machine_type"] or "").strip().lower()
+        if not machine_type:
+            continue
+        tier = (row["tier"] or "").strip()
+        available.setdefault(machine_type, set()).add(tier)
+    return available
+
+
+def _recipe_machine_available(row: sqlite3.Row, available_machines: dict[str, set[str]]) -> bool:
+    method = (row["method"] or "machine").strip().lower()
+    if method != "machine":
+        return True
+    machine_type = (row["machine"] or "").strip().lower()
+    if not machine_type:
+        return True
+    tiers = available_machines.get(machine_type)
+    if not tiers:
+        return False
+    tier = (row["tier"] or "").strip() or (row["machine_item_tier"] or "").strip()
+    if not tier:
+        return True
+    return tier in tiers
+
+
+def fetch_recipes(
+    conn: sqlite3.Connection,
+    enabled_tiers: list[str],
+    available_machines: dict[str, set[str]] | None = None,
+) -> list[sqlite3.Row]:
     if not enabled_tiers:
         enabled_tiers = ["Stone Age"]
     placeholders = ",".join(["?"] * len(enabled_tiers))
     sql = (
-        "SELECT id, name, method, machine, machine_item_id, grid_size, station_item_id, tier, circuit, duration_ticks, "
-        "       eu_per_tick, duplicate_of_recipe_id "
-        "FROM recipes "
-        f"WHERE (tier IS NULL OR TRIM(tier)='' OR tier IN ({placeholders})) "
-        "ORDER BY name"
+        "SELECT r.id, r.name, r.method, r.machine, r.machine_item_id, r.grid_size, r.station_item_id, "
+        "       r.tier, r.circuit, r.duration_ticks, r.eu_per_tick, r.duplicate_of_recipe_id, "
+        "       mi.machine_tier AS machine_item_tier "
+        "FROM recipes r "
+        "LEFT JOIN items mi ON mi.id = r.machine_item_id "
+        f"WHERE (r.tier IS NULL OR TRIM(r.tier)='' OR r.tier IN ({placeholders})) "
+        "ORDER BY r.name"
     )
-    return conn.execute(sql, tuple(enabled_tiers)).fetchall()
+    rows = conn.execute(sql, tuple(enabled_tiers)).fetchall()
+    if not available_machines:
+        return rows
+    return [row for row in rows if _recipe_machine_available(row, available_machines)]
 
 
 def fetch_recipe_lines(conn: sqlite3.Connection, recipe_id: int) -> list[sqlite3.Row]:

--- a/ui_main.py
+++ b/ui_main.py
@@ -9,7 +9,7 @@ from PySide6 import QtCore, QtGui, QtWidgets
 from services.db import DEFAULT_DB_PATH, find_item_merge_conflicts
 from services.db_lifecycle import DbLifecycle
 from services.items import fetch_items
-from services.recipes import fetch_recipes
+from services.recipes import fetch_recipes, load_online_machine_availability
 from services.tab_config import apply_tab_reorder, config_path, load_tab_config, save_tab_config
 from ui_dialogs import ItemMergeConflictDialog
 from ui_tabs.inventory_tab import InventoryTab
@@ -609,14 +609,16 @@ class App(QtWidgets.QMainWindow):
             inventory_widget.render_items(self.items)
 
     def refresh_recipes(self) -> None:
+        available_machines = load_online_machine_availability(self.profile_conn)
         try:
-            self.recipes = fetch_recipes(self.conn, self.get_enabled_tiers())
+            self.recipes = fetch_recipes(self.conn, self.get_enabled_tiers(), available_machines)
         except sqlite3.ProgrammingError as exc:
             if "closed" not in str(exc).lower():
                 raise
             self.db.switch_db(self.db_path)
             self._sync_db_handles()
-            self.recipes = fetch_recipes(self.conn, self.get_enabled_tiers())
+            available_machines = load_online_machine_availability(self.profile_conn)
+            self.recipes = fetch_recipes(self.conn, self.get_enabled_tiers(), available_machines)
         widget = self.tab_widgets.get("recipes")
         if widget and hasattr(widget, "render_recipes"):
             widget.render_recipes(self.recipes)


### PR DESCRIPTION
### Motivation
- Ensure the Recipes list respects which machine types and tiers are currently online in the profile database so users don't see machine recipes they cannot run.
- Extend recipe fetching to accept machine availability context while keeping the existing tier filtering as the base filter.

### Description
- Added `load_online_machine_availability` to `services/recipes.py` to read online machine tiers from the profile DB.
- Added internal `_recipe_machine_available` helper and extended `fetch_recipes` to accept an `available_machines` map and filter out machine-method recipes whose machine/tier is not online.
- Included `mi.machine_tier` via a `LEFT JOIN` in the recipe query so item-tagged machine tiers are considered when filtering.
- Updated `ui_main.refresh_recipes` to call `load_online_machine_availability(self.profile_conn)` and pass the result into `fetch_recipes`.

### Testing
- Ran `pytest` which executed the test suite. 
- Result: `16 passed, 1 skipped` and no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696057a91bbc832bbf28d51806341a0b)