### PR TITLE
Add tests for machine availability owned/online constraints

### DIFF
--- a/tests/test_machine_availability_state.py
+++ b/tests/test_machine_availability_state.py
@@ -1,0 +1,34 @@
+import sqlite3
+
+import pytest
+
+from services import db
+
+
+def test_machine_availability_rejects_online_over_owned():
+    conn = db.connect_profile(":memory:")
+    try:
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO machine_availability(machine_type, tier, owned, online) VALUES(?,?,?,?)",
+                ("lathe", "MV", 1, 2),
+            )
+    finally:
+        conn.close()
+
+
+def test_machine_availability_rejects_invalid_transition():
+    conn = db.connect_profile(":memory:")
+    try:
+        conn.execute(
+            "INSERT INTO machine_availability(machine_type, tier, owned, online) VALUES(?,?,?,?)",
+            ("lathe", "MV", 1, 1),
+        )
+
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "UPDATE machine_availability SET owned=?, online=? WHERE machine_type=? AND tier=?",
+                (0, 1, "lathe", "MV"),
+            )
+    finally:
+        conn.close()


### PR DESCRIPTION
### Motivation
- Add coverage for UI/state constraints around machine availability (owned vs online) in the profile DB.
- Verify that invalid state transitions (online > owned or reducing owned below online) are blocked at the state layer.
- Ensure the DB-level constraints that enforce `online <= owned` are exercised by automated tests.

### Description
- Add `tests/test_machine_availability_state.py` containing state-level tests for machine availability.
- Add a test that inserting a row with `online > owned` via `db.connect_profile(":memory:")` raises `sqlite3.IntegrityError`.
- Add a test that updating a row to make `owned` less than `online` raises `sqlite3.IntegrityError`.
- Tests operate against an in-memory profile DB so they exercise the schema checks directly.

### Testing
- Ran `pytest` which executed the full test suite and passed (`20 passed, 1 skipped`).
- The run showed a `PySide6` import warning in the environment but it did not cause failures.
- Tests completed successfully in the CI-like local run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696072ce579c832b8a0ea99c3787f3c2)