### PR TITLE
Update item material none label

### DIFF
--- a/ui_dialogs.py
+++ b/ui_dialogs.py
@@ -30,7 +30,7 @@ NONE_TIER_LABEL = "— none —"
 # Separate label for Item Kind "none" (stored as NULL)
 NONE_KIND_LABEL = "— none —"
 
-NONE_MATERIAL_LABEL = "— none —"
+NONE_MATERIAL_LABEL = "(None)"
 
 ADD_NEW_KIND_LABEL = "+ Add new…"
 


### PR DESCRIPTION
### Motivation
- Make the user-facing label for items with no material clearer and consistent in dialogs.
- Surface a distinct, unambiguous placeholder for the material combo box when an item has no material.

### Description
- Change the `NONE_MATERIAL_LABEL` constant in `ui_dialogs.py` from `"— none —"` to `"(None)"`.
- This updates the text shown in the Material combo box across add/edit item dialogs.

### Testing
- Ran `pytest` as part of the change validation. 
- Test run completed with `21 passed, 1 skipped` and a single import warning, and no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696094807668832b947f735b7548d29c)