### PR TITLE
Add manual automation lifecycle tracker tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A recipe database browser and inventory helper for GregTech New Horizons.
   - Applies machine-capacity hard filtering (item slots + fluid tanks) so impossible machine variants are excluded before ranking.
 - **Interactive Build Mode** with step-by-step instructions tied to inventory updates.
 - **Machine tracking** for owned/online availability used by planning and machine selection.
+- **Automation tracker tab** for manually building full processing chains (machine -> output -> next machine), including optional byproducts and per-step status.
 - **Storage-aware inventory workflows**: active storage selection, aggregate read-only mode, per-storage totals, and storage CRUD management.
   - Storage list ordering is now aligned with planner consumption ordering (`priority DESC`, then name/id tie-breakers).
   - `Main Storage` uses its configured priority like any other storage unit.

--- a/services/automation.py
+++ b/services/automation.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import sqlite3
+
+
+def list_plans(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+    return conn.execute(
+        """
+        SELECT id, name, COALESCE(notes, '') AS notes
+        FROM automation_plans
+        ORDER BY name COLLATE NOCASE
+        """
+    ).fetchall()
+
+
+def create_plan(conn: sqlite3.Connection, name: str, notes: str = "") -> int:
+    cur = conn.execute(
+        "INSERT INTO automation_plans(name, notes) VALUES(?, ?)",
+        (name.strip(), notes.strip() or None),
+    )
+    conn.commit()
+    return int(cur.lastrowid)
+
+
+def list_steps(conn: sqlite3.Connection, plan_id: int) -> list[sqlite3.Row]:
+    return conn.execute(
+        """
+        SELECT id, step_order, machine_name, input_name, output_name, COALESCE(byproduct_name, '') AS byproduct_name,
+               status, COALESCE(notes, '') AS notes
+        FROM automation_steps
+        WHERE plan_id = ?
+        ORDER BY step_order, id
+        """,
+        (plan_id,),
+    ).fetchall()
+
+
+def add_step(
+    conn: sqlite3.Connection,
+    *,
+    plan_id: int,
+    machine_name: str,
+    input_name: str,
+    output_name: str,
+    byproduct_name: str = "",
+    notes: str = "",
+) -> int:
+    row = conn.execute(
+        "SELECT COALESCE(MAX(step_order), 0) + 1 AS next_order FROM automation_steps WHERE plan_id = ?",
+        (plan_id,),
+    ).fetchone()
+    next_order = int(row["next_order"] if row is not None else 1)
+    cur = conn.execute(
+        """
+        INSERT INTO automation_steps(
+            plan_id, step_order, machine_name, input_name, output_name, byproduct_name, notes
+        ) VALUES(?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            plan_id,
+            next_order,
+            machine_name.strip(),
+            input_name.strip(),
+            output_name.strip(),
+            byproduct_name.strip() or None,
+            notes.strip() or None,
+        ),
+    )
+    conn.commit()
+    return int(cur.lastrowid)
+
+
+def update_step_status(conn: sqlite3.Connection, step_id: int, status: str) -> None:
+    conn.execute(
+        "UPDATE automation_steps SET status = ? WHERE id = ?",
+        (status, step_id),
+    )
+    conn.commit()
+
+
+def delete_step(conn: sqlite3.Connection, step_id: int) -> None:
+    conn.execute("DELETE FROM automation_steps WHERE id = ?", (step_id,))
+    conn.commit()

--- a/services/automation.py
+++ b/services/automation.py
@@ -25,7 +25,11 @@ def create_plan(conn: sqlite3.Connection, name: str, notes: str = "") -> int:
 def list_steps(conn: sqlite3.Connection, plan_id: int) -> list[sqlite3.Row]:
     return conn.execute(
         """
-        SELECT id, step_order, machine_name, input_name, output_name, COALESCE(byproduct_name, '') AS byproduct_name,
+        SELECT id, step_order,
+               machine_item_id, machine_name,
+               input_item_id, input_name,
+               output_item_id, output_name,
+               byproduct_item_id, COALESCE(byproduct_name, '') AS byproduct_name,
                status, COALESCE(notes, '') AS notes
         FROM automation_steps
         WHERE plan_id = ?
@@ -39,9 +43,13 @@ def add_step(
     conn: sqlite3.Connection,
     *,
     plan_id: int,
+    machine_item_id: int,
     machine_name: str,
+    input_item_id: int,
     input_name: str,
+    output_item_id: int,
     output_name: str,
+    byproduct_item_id: int | None = None,
     byproduct_name: str = "",
     notes: str = "",
 ) -> int:
@@ -53,15 +61,29 @@ def add_step(
     cur = conn.execute(
         """
         INSERT INTO automation_steps(
-            plan_id, step_order, machine_name, input_name, output_name, byproduct_name, notes
-        ) VALUES(?, ?, ?, ?, ?, ?, ?)
+            plan_id,
+            step_order,
+            machine_item_id,
+            machine_name,
+            input_item_id,
+            input_name,
+            output_item_id,
+            output_name,
+            byproduct_item_id,
+            byproduct_name,
+            notes
+        ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             plan_id,
             next_order,
+            machine_item_id,
             machine_name.strip(),
+            input_item_id,
             input_name.strip(),
+            output_item_id,
             output_name.strip(),
+            byproduct_item_id,
             byproduct_name.strip() or None,
             notes.strip() or None,
         ),

--- a/services/db.py
+++ b/services/db.py
@@ -151,6 +151,32 @@ def connect_profile(db_path: Path | str) -> sqlite3.Connection:
     )
     conn.execute(
         """
+        CREATE TABLE IF NOT EXISTS automation_plans (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL UNIQUE,
+            notes TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS automation_steps (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            plan_id INTEGER NOT NULL,
+            step_order INTEGER NOT NULL,
+            machine_name TEXT NOT NULL,
+            input_name TEXT NOT NULL,
+            output_name TEXT NOT NULL,
+            byproduct_name TEXT,
+            status TEXT NOT NULL DEFAULT 'planned' CHECK(status IN ('planned', 'active', 'complete')),
+            notes TEXT,
+            FOREIGN KEY(plan_id) REFERENCES automation_plans(id) ON DELETE CASCADE,
+            UNIQUE(plan_id, step_order)
+        )
+        """
+    )
+    conn.execute(
+        """
         INSERT INTO app_settings(key, value)
         VALUES('machine_availability_version', '0')
         ON CONFLICT(key) DO NOTHING

--- a/services/db.py
+++ b/services/db.py
@@ -164,9 +164,13 @@ def connect_profile(db_path: Path | str) -> sqlite3.Connection:
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             plan_id INTEGER NOT NULL,
             step_order INTEGER NOT NULL,
+            machine_item_id INTEGER,
             machine_name TEXT NOT NULL,
+            input_item_id INTEGER,
             input_name TEXT NOT NULL,
+            output_item_id INTEGER,
             output_name TEXT NOT NULL,
+            byproduct_item_id INTEGER,
             byproduct_name TEXT,
             status TEXT NOT NULL DEFAULT 'planned' CHECK(status IN ('planned', 'active', 'complete')),
             notes TEXT,
@@ -175,6 +179,19 @@ def connect_profile(db_path: Path | str) -> sqlite3.Connection:
         )
         """
     )
+    automation_step_cols = {
+        row["name"]
+        for row in conn.execute("PRAGMA table_info(automation_steps)").fetchall()
+    }
+    if "machine_item_id" not in automation_step_cols:
+        conn.execute("ALTER TABLE automation_steps ADD COLUMN machine_item_id INTEGER")
+    if "input_item_id" not in automation_step_cols:
+        conn.execute("ALTER TABLE automation_steps ADD COLUMN input_item_id INTEGER")
+    if "output_item_id" not in automation_step_cols:
+        conn.execute("ALTER TABLE automation_steps ADD COLUMN output_item_id INTEGER")
+    if "byproduct_item_id" not in automation_step_cols:
+        conn.execute("ALTER TABLE automation_steps ADD COLUMN byproduct_item_id INTEGER")
+
     conn.execute(
         """
         INSERT INTO app_settings(key, value)

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -1,0 +1,31 @@
+from services.automation import add_step, create_plan, list_plans, list_steps, update_step_status, delete_step
+from services.db import connect_profile
+
+
+def test_automation_plan_lifecycle(tmp_path):
+    conn = connect_profile(tmp_path / "profile.db")
+
+    plan_id = create_plan(conn, "Ore Processing")
+    plans = list_plans(conn)
+    assert [row["name"] for row in plans] == ["Ore Processing"]
+
+    step_id = add_step(
+        conn,
+        plan_id=plan_id,
+        machine_name="Macerator",
+        input_name="Iron Ore",
+        output_name="Crushed Iron Ore",
+        byproduct_name="Stone Dust",
+    )
+    steps = list_steps(conn, plan_id)
+    assert len(steps) == 1
+    assert steps[0]["id"] == step_id
+    assert steps[0]["step_order"] == 1
+    assert steps[0]["status"] == "planned"
+
+    update_step_status(conn, step_id, "active")
+    steps = list_steps(conn, plan_id)
+    assert steps[0]["status"] == "active"
+
+    delete_step(conn, step_id)
+    assert list_steps(conn, plan_id) == []

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -12,9 +12,13 @@ def test_automation_plan_lifecycle(tmp_path):
     step_id = add_step(
         conn,
         plan_id=plan_id,
+        machine_item_id=10,
         machine_name="Macerator",
+        input_item_id=11,
         input_name="Iron Ore",
+        output_item_id=12,
         output_name="Crushed Iron Ore",
+        byproduct_item_id=13,
         byproduct_name="Stone Dust",
     )
     steps = list_steps(conn, plan_id)
@@ -22,6 +26,10 @@ def test_automation_plan_lifecycle(tmp_path):
     assert steps[0]["id"] == step_id
     assert steps[0]["step_order"] == 1
     assert steps[0]["status"] == "planned"
+    assert steps[0]["machine_item_id"] == 10
+    assert steps[0]["input_item_id"] == 11
+    assert steps[0]["output_item_id"] == 12
+    assert steps[0]["byproduct_item_id"] == 13
 
     update_step_status(conn, step_id, "active")
     steps = list_steps(conn, plan_id)

--- a/ui_main.py
+++ b/ui_main.py
@@ -26,6 +26,7 @@ from ui_tabs.recipes_tab_qt import RecipesTab
 from ui_tabs.planner_tab_qt import PlannerTab
 from ui_tabs.tiers_tab import TiersTab
 from ui_tabs.machines_tab import MachinesTab
+from ui_tabs.automation_tab import AutomationTab
 from ui_constants import DARK_STYLESHEET, LIGHT_STYLESHEET
 from ui_dialog_sizing import install_dialog_sizing_hooks
 
@@ -150,6 +151,7 @@ class App(QtWidgets.QMainWindow):
             "planner": {"label": "Planner"},
             "tiers": {"label": "Tiers"},
             "machines": {"label": "Machines"},
+            "automation": {"label": "Automation"},
         }
         self.tab_order, self.enabled_tabs = self._load_ui_config()
         self.tab_actions: dict[str, QtGui.QAction] = {}
@@ -243,6 +245,8 @@ class App(QtWidgets.QMainWindow):
             widget = PlannerTab(self, self)
         elif tab_id == "machines":
             widget = MachinesTab(self, self)
+        elif tab_id == "automation":
+            widget = AutomationTab(self, self)
         else:
             widget = PlaceholderTab(label)
         widget.setProperty("tab_id", tab_id)

--- a/ui_tabs/automation_tab.py
+++ b/ui_tabs/automation_tab.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import sqlite3
+
+from PySide6 import QtCore, QtWidgets
+
+from services.automation import add_step, create_plan, delete_step, list_plans, list_steps, update_step_status
+
+
+class AutomationTab(QtWidgets.QWidget):
+    def __init__(self, app, parent=None):
+        super().__init__(parent)
+        self.app = app
+        self._plan_id: int | None = None
+
+        root = QtWidgets.QVBoxLayout(self)
+        root.addWidget(
+            QtWidgets.QLabel(
+                "Track end-to-end automation flows (ore -> crushed -> washed -> dust -> centrifuge) "
+                "including optional byproducts."
+            )
+        )
+
+        top = QtWidgets.QHBoxLayout()
+        root.addLayout(top)
+        top.addWidget(QtWidgets.QLabel("Plan:"))
+        self.plan_combo = QtWidgets.QComboBox()
+        self.plan_combo.currentIndexChanged.connect(self._on_plan_changed)
+        top.addWidget(self.plan_combo, stretch=1)
+        self.new_plan_btn = QtWidgets.QPushButton("New Plan…")
+        self.new_plan_btn.clicked.connect(self._create_plan)
+        top.addWidget(self.new_plan_btn)
+
+        self.table = QtWidgets.QTableWidget(0, 7)
+        self.table.setHorizontalHeaderLabels([
+            "#",
+            "Machine",
+            "Input",
+            "Output",
+            "Byproduct",
+            "Status",
+            "Notes",
+        ])
+        self.table.horizontalHeader().setStretchLastSection(True)
+        self.table.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows)
+        self.table.setEditTriggers(QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers)
+        root.addWidget(self.table, stretch=1)
+
+        buttons = QtWidgets.QHBoxLayout()
+        root.addLayout(buttons)
+        self.add_step_btn = QtWidgets.QPushButton("Add Step…")
+        self.add_step_btn.clicked.connect(self._add_step)
+        self.advance_btn = QtWidgets.QPushButton("Advance Status")
+        self.advance_btn.clicked.connect(self._advance_status)
+        self.remove_btn = QtWidgets.QPushButton("Remove Step")
+        self.remove_btn.clicked.connect(self._remove_step)
+        buttons.addWidget(self.add_step_btn)
+        buttons.addWidget(self.advance_btn)
+        buttons.addWidget(self.remove_btn)
+        buttons.addStretch(1)
+
+        self.refresh()
+
+    def refresh(self) -> None:
+        plans = list_plans(self.app.profile_conn)
+        selected = self._plan_id
+        self.plan_combo.blockSignals(True)
+        self.plan_combo.clear()
+        for row in plans:
+            self.plan_combo.addItem(row["name"], int(row["id"]))
+        self.plan_combo.blockSignals(False)
+
+        if not plans:
+            self._plan_id = None
+            self.table.setRowCount(0)
+            return
+
+        if selected is not None:
+            idx = self.plan_combo.findData(selected)
+            if idx >= 0:
+                self.plan_combo.setCurrentIndex(idx)
+        if self.plan_combo.currentIndex() < 0:
+            self.plan_combo.setCurrentIndex(0)
+        self._on_plan_changed(self.plan_combo.currentIndex())
+
+    def _on_plan_changed(self, _index: int) -> None:
+        plan_id = self.plan_combo.currentData()
+        self._plan_id = int(plan_id) if plan_id is not None else None
+        self._load_steps()
+
+    def _load_steps(self) -> None:
+        self.table.setRowCount(0)
+        if self._plan_id is None:
+            return
+        for row in list_steps(self.app.profile_conn, self._plan_id):
+            row_idx = self.table.rowCount()
+            self.table.insertRow(row_idx)
+            self.table.setItem(row_idx, 0, self._item(str(row["step_order"]), row["id"]))
+            self.table.setItem(row_idx, 1, QtWidgets.QTableWidgetItem(row["machine_name"]))
+            self.table.setItem(row_idx, 2, QtWidgets.QTableWidgetItem(row["input_name"]))
+            self.table.setItem(row_idx, 3, QtWidgets.QTableWidgetItem(row["output_name"]))
+            self.table.setItem(row_idx, 4, QtWidgets.QTableWidgetItem(row["byproduct_name"]))
+            self.table.setItem(row_idx, 5, QtWidgets.QTableWidgetItem(row["status"]))
+            self.table.setItem(row_idx, 6, QtWidgets.QTableWidgetItem(row["notes"]))
+
+    def _item(self, text: str, step_id: int) -> QtWidgets.QTableWidgetItem:
+        item = QtWidgets.QTableWidgetItem(text)
+        item.setData(QtCore.Qt.ItemDataRole.UserRole, step_id)
+        return item
+
+    def _create_plan(self) -> None:
+        name, ok = QtWidgets.QInputDialog.getText(self, "New automation plan", "Plan name:")
+        if not ok or not name.strip():
+            return
+        try:
+            plan_id = create_plan(self.app.profile_conn, name)
+        except sqlite3.IntegrityError:
+            QtWidgets.QMessageBox.warning(self, "Plan exists", "A plan with that name already exists.")
+            return
+        self._plan_id = plan_id
+        self.refresh()
+
+    def _add_step(self) -> None:
+        if self._plan_id is None:
+            QtWidgets.QMessageBox.information(self, "No plan", "Create a plan first.")
+            return
+
+        machine, ok = QtWidgets.QInputDialog.getText(self, "Machine", "Machine:")
+        if not ok or not machine.strip():
+            return
+        input_name, ok = QtWidgets.QInputDialog.getText(self, "Input", "Input item/fluid:")
+        if not ok or not input_name.strip():
+            return
+        output_name, ok = QtWidgets.QInputDialog.getText(self, "Output", "Output item/fluid:")
+        if not ok or not output_name.strip():
+            return
+        byproduct, _ = QtWidgets.QInputDialog.getText(self, "Byproduct (optional)", "Byproduct:")
+
+        add_step(
+            self.app.profile_conn,
+            plan_id=self._plan_id,
+            machine_name=machine,
+            input_name=input_name,
+            output_name=output_name,
+            byproduct_name=byproduct,
+        )
+        self._load_steps()
+
+    def _selected_step_id(self) -> int | None:
+        row = self.table.currentRow()
+        if row < 0:
+            return None
+        id_item = self.table.item(row, 0)
+        if id_item is None:
+            return None
+        step_id = id_item.data(QtCore.Qt.ItemDataRole.UserRole)
+        return int(step_id) if step_id is not None else None
+
+    def _advance_status(self) -> None:
+        row = self.table.currentRow()
+        step_id = self._selected_step_id()
+        if row < 0 or step_id is None:
+            return
+        status_item = self.table.item(row, 5)
+        if status_item is None:
+            return
+        current = status_item.text().strip().lower()
+        next_status = "active" if current == "planned" else "complete"
+        if current == "complete":
+            next_status = "planned"
+        update_step_status(self.app.profile_conn, step_id, next_status)
+        self._load_steps()
+
+    def _remove_step(self) -> None:
+        step_id = self._selected_step_id()
+        if step_id is None:
+            return
+        delete_step(self.app.profile_conn, step_id)
+        self._load_steps()


### PR DESCRIPTION
### Motivation
- Provide a manual automation tracker so users can plan and track full item processing chains (e.g., ore → crushed → washed → purified dust → centrifuge) with optional byproduct handling and per-step status.

### Description
- Persist automation pipelines in the profile DB by adding `automation_plans` and `automation_steps` tables with ordering and `status` constraints.
- Add service-level CRUD helpers in `services/automation.py` (`list_plans`, `create_plan`, `list_steps`, `add_step`, `update_step_status`, `delete_step`) to keep data logic separate from the UI.
- Implement a new `Automation` tab UI in `ui_tabs/automation_tab.py` for creating plans, adding ordered machine steps (input/output/byproduct), advancing step status, and removing steps, and register it in `ui_main.py` so it behaves like other tabs.
- Document the feature in `README.md` and add a service-level test `tests/test_automation_service.py` covering the plan/step lifecycle.

### Testing
- Ran the full test suite with `pytest -q`, which failed during test collection due to a missing system library required by PySide6 (`libGL.so.1`) in the environment.
- Executed targeted tests with `pytest -q tests/test_automation_service.py tests/test_tab_config.py tests/test_db_schema.py`, and all selected tests passed (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bb8017a2c832b92758e7cbee33e99)